### PR TITLE
Update teamnet spec + fix useMultipleUserBalances

### DIFF
--- a/apps/ui/src/config/tokens.ts
+++ b/apps/ui/src/config/tokens.ts
@@ -799,20 +799,6 @@ const localnetTokens: readonly TokenSpec[] = [
           decimals: 6,
         },
       ],
-      [
-        EcosystemId.Ethereum,
-        {
-          address: "0x2A63108d7D592822Ddcf5d270Ba227A39bB982DA",
-          decimals: 6,
-        },
-      ],
-      [
-        EcosystemId.Bsc,
-        {
-          address: "0x8d4bD97855708599B11F1960cb22A92f4Bdf0532",
-          decimals: 6,
-        },
-      ],
     ]),
   },
   {

--- a/apps/ui/src/hooks/crossEcosystem/useMultipleUserBalances.ts
+++ b/apps/ui/src/hooks/crossEcosystem/useMultipleUserBalances.ts
@@ -68,7 +68,9 @@ const getEvmTokenIdAndBalance = (
   if (!address) {
     return [tokenSpec.id, null];
   }
-  const index = contractAddresses.findIndex((x) => x === address);
+  const index = contractAddresses.findIndex(
+    (contractAddress) => contractAddress === address,
+  );
   if (!balances[index]) {
     return [tokenSpec.id, null];
   }


### PR DESCRIPTION
I went through [DEV_SETUP](https://github.com/swim-io/swim/blob/master/docs/DEV_SETUP.md) and update the teamnet spec.

When I'm trying to Add Pool, got an error because `useMultipleUserBalances` always return 0 balance for BSC even BSC wallet is connected.

It's due to `useMultipleUserBalances` is reading the balance from wrong index, also fixed in this PR

Now able to read the correct balance and Add Pool
<img width="666" alt="Stablecoin_Hexa-Pool___Swim" src="https://user-images.githubusercontent.com/101085251/167101887-d5820945-ca55-421c-8a93-356e76d47295.png">

