### PR TITLE
Load Polygon and Avalanche gas price only when additional evm chains are enabled

### DIFF
--- a/apps/ui/src/hooks/swim/useGasPriceQuery.ts
+++ b/apps/ui/src/hooks/swim/useGasPriceQuery.ts
@@ -3,6 +3,7 @@ import type { UseQueryResult } from "react-query";
 import { useQuery } from "react-query";
 
 import type { EvmEcosystemId } from "../../config";
+import { EcosystemId } from "../../config";
 import { useEnvironment, useEvmConnection } from "../../contexts";
 
 // Query for gas price in native currency
@@ -13,6 +14,14 @@ export const useGasPriceQuery = (
   const { env } = useEnvironment();
   const connection = useEvmConnection(evmEcosystemId);
   return useQuery(["gasPrice", env, evmEcosystemId], async () => {
+    if (
+      !process.env.REACT_APP_ADDITIONAL_EVM_CHAINS &&
+      (evmEcosystemId === EcosystemId.Avalanche ||
+        evmEcosystemId === EcosystemId.Polygon)
+    ) {
+      return new Decimal(0);
+    }
+
     // The BSC connection still returns the gas price in "wei" (ie 1e-18 BNB)
     // even though this is not a valid unit of BNB
     const gasPriceInWei = await connection.provider.getGasPrice();


### PR DESCRIPTION
As title.

Since React hook can't be call conditionally, best place to use the feature flag `REACT_APP_ADDITIONAL_EVM_CHAINS` is before we call the JSON RPC endpoint