### PR TITLE
Add new test util renderHookWithAppContext

### DIFF
--- a/apps/ui/src/hooks/interaction/useInteraction.test.ts
+++ b/apps/ui/src/hooks/interaction/useInteraction.test.ts
@@ -1,13 +1,11 @@
-import { renderHook } from "@testing-library/react-hooks";
 import { useQueryClient } from "react-query";
 
-import { AppContext } from "../../contexts/appContext";
 import {
   ETH_USDC_TO_SOL_USDC_SWAP,
   SWAP_INTERACTIONS,
 } from "../../fixtures/swim/interactions";
 import { loadInteractions } from "../../models";
-import { mockOf } from "../../testUtils";
+import { mockOf, renderHookWithAppContext } from "../../testUtils";
 
 import { useInteraction } from "./useInteraction";
 
@@ -22,27 +20,22 @@ const loadInteractionsMock = mockOf(loadInteractions);
 describe("useInteraction", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   it("should return found interaction", async () => {
     loadInteractionsMock.mockReturnValue(SWAP_INTERACTIONS);
-    const { result } = renderHook(
-      () => useInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
-      {
-        wrapper: AppContext,
-      },
+    const { result } = renderHookWithAppContext(() =>
+      useInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
     );
     expect(result.current).toEqual(ETH_USDC_TO_SOL_USDC_SWAP);
   });
 
   it("should throw if interaction not found", async () => {
     loadInteractionsMock.mockReturnValue(SWAP_INTERACTIONS);
-    const { result } = renderHook(() => useInteraction("INVALID_ID"), {
-      wrapper: AppContext,
-    });
+    const { result } = renderHookWithAppContext(() =>
+      useInteraction("INVALID_ID"),
+    );
     expect(result.error?.message).toEqual("Interaction not found");
   });
 });

--- a/apps/ui/src/hooks/interaction/useRequiredEcosystemsForInteraction.test.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredEcosystemsForInteraction.test.ts
@@ -1,15 +1,13 @@
-import { renderHook } from "@testing-library/react-hooks";
 import { useQueryClient } from "react-query";
 
 import { EcosystemId } from "../../config";
-import { AppContext } from "../../contexts/appContext";
 import {
   BSC_USDT_TO_ETH_USDC_SWAP,
   ETH_USDC_TO_SOL_USDC_SWAP,
   SOL_USDC_TO_ETH_USDC_SWAP,
   SOL_USDC_TO_SOL_USDT_SWAP,
 } from "../../fixtures/swim/interactions";
-import { mockOf } from "../../testUtils";
+import { mockOf, renderHookWithAppContext } from "../../testUtils";
 
 import { useInteraction } from "./useInteraction";
 import { useRequiredEcosystemsForInteraction } from "./useRequiredEcosystemsForInteraction";
@@ -25,18 +23,13 @@ const useInteractionMock = mockOf(useInteraction);
 describe("useRequiredEcosystemsForInteraction", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   it("should return required ecosystems for ETH to SOL Swap", async () => {
     useInteractionMock.mockReturnValue(ETH_USDC_TO_SOL_USDC_SWAP);
-    const { result } = renderHook(
-      () => useRequiredEcosystemsForInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
-      {
-        wrapper: AppContext,
-      },
+    const { result } = renderHookWithAppContext(() =>
+      useRequiredEcosystemsForInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
     );
     expect(result.current).toEqual(
       new Set([EcosystemId.Ethereum, EcosystemId.Solana]),
@@ -45,11 +38,8 @@ describe("useRequiredEcosystemsForInteraction", () => {
 
   it("should return required ecosystems for SOL to ETH Swap", async () => {
     useInteractionMock.mockReturnValue(SOL_USDC_TO_ETH_USDC_SWAP);
-    const { result } = renderHook(
-      () => useRequiredEcosystemsForInteraction(SOL_USDC_TO_ETH_USDC_SWAP.id),
-      {
-        wrapper: AppContext,
-      },
+    const { result } = renderHookWithAppContext(() =>
+      useRequiredEcosystemsForInteraction(SOL_USDC_TO_ETH_USDC_SWAP.id),
     );
     expect(result.current).toEqual(
       new Set([EcosystemId.Ethereum, EcosystemId.Solana]),
@@ -58,22 +48,16 @@ describe("useRequiredEcosystemsForInteraction", () => {
 
   it("should return required ecosystems for SOL to SOL Swap", async () => {
     useInteractionMock.mockReturnValue(SOL_USDC_TO_SOL_USDT_SWAP);
-    const { result } = renderHook(
-      () => useRequiredEcosystemsForInteraction(SOL_USDC_TO_SOL_USDT_SWAP.id),
-      {
-        wrapper: AppContext,
-      },
+    const { result } = renderHookWithAppContext(() =>
+      useRequiredEcosystemsForInteraction(SOL_USDC_TO_SOL_USDT_SWAP.id),
     );
     expect(result.current).toEqual(new Set([EcosystemId.Solana]));
   });
 
   it("should return required ecosystems for BSC to ETH Swap", async () => {
     useInteractionMock.mockReturnValue(BSC_USDT_TO_ETH_USDC_SWAP);
-    const { result } = renderHook(
-      () => useRequiredEcosystemsForInteraction(BSC_USDT_TO_ETH_USDC_SWAP.id),
-      {
-        wrapper: AppContext,
-      },
+    const { result } = renderHookWithAppContext(() =>
+      useRequiredEcosystemsForInteraction(BSC_USDT_TO_ETH_USDC_SWAP.id),
     );
     expect(result.current).toEqual(
       new Set([EcosystemId.Ethereum, EcosystemId.Solana, EcosystemId.Bsc]),

--- a/apps/ui/src/hooks/solana/useSolBalanceQuery.test.ts
+++ b/apps/ui/src/hooks/solana/useSolBalanceQuery.test.ts
@@ -1,10 +1,8 @@
-import { renderHook } from "@testing-library/react-hooks";
 import Decimal from "decimal.js";
 import { useQueryClient } from "react-query";
 
 import { useSolanaConnection, useSolanaWallet } from "../../contexts";
-import { AppContext } from "../../contexts/appContext";
-import { mockOf } from "../../testUtils";
+import { mockOf, renderHookWithAppContext } from "../../testUtils";
 
 import { useSolBalanceQuery } from "./useSolBalanceQuery";
 
@@ -21,9 +19,7 @@ const useSolanaConnectionMock = mockOf(useSolanaConnection);
 describe("useSolBalanceQuery", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   it("should return 0 when no address", async () => {
@@ -31,9 +27,9 @@ describe("useSolBalanceQuery", () => {
     useSolanaConnectionMock.mockReturnValue({
       getBalance: async () => 999,
     });
-    const { result, waitFor } = renderHook(() => useSolBalanceQuery(), {
-      wrapper: AppContext,
-    });
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSolBalanceQuery(),
+    );
     await waitFor(() => result.current.isSuccess);
     expect(result.current.data).toEqual(new Decimal("0"));
   });
@@ -45,9 +41,9 @@ describe("useSolBalanceQuery", () => {
     useSolanaConnectionMock.mockReturnValue({
       getBalance: async () => 999,
     });
-    const { result, waitFor } = renderHook(() => useSolBalanceQuery(), {
-      wrapper: AppContext,
-    });
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSolBalanceQuery(),
+    );
     await waitFor(() => result.current.isSuccess);
     expect(result.current.data).toEqual(new Decimal("999"));
   });
@@ -61,9 +57,9 @@ describe("useSolBalanceQuery", () => {
         throw new Error("Something went wrong");
       },
     });
-    const { result, waitFor } = renderHook(() => useSolBalanceQuery(), {
-      wrapper: AppContext,
-    });
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSolBalanceQuery(),
+    );
     await waitFor(() => result.current.isSuccess);
     expect(result.current.data).toEqual(new Decimal("0"));
   });

--- a/apps/ui/src/hooks/swim/useAddFeesEstimationQuery.test.ts
+++ b/apps/ui/src/hooks/swim/useAddFeesEstimationQuery.test.ts
@@ -1,11 +1,13 @@
-import { renderHook } from "@testing-library/react-hooks";
 import Decimal from "decimal.js";
 import { useQueryClient } from "react-query";
 
 import { EcosystemId } from "../../config";
-import { AppContext } from "../../contexts";
 import { Amount } from "../../models";
-import { findLocalnetTokenById, mockOf } from "../../testUtils";
+import {
+  findLocalnetTokenById,
+  mockOf,
+  renderHookWithAppContext,
+} from "../../testUtils";
 
 import { useAddFeesEstimationQuery } from "./useAddFeesEstimationQuery";
 import { useGasPriceQuery } from "./useGasPriceQuery";
@@ -27,9 +29,7 @@ const BSC_USDT = findLocalnetTokenById("localnet-bsc-usdt");
 describe("useAddFeesEstimationQuery", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   describe("loading", () => {
@@ -38,22 +38,18 @@ describe("useAddFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(
-        () =>
-          useAddFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(99)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Solana,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useAddFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(99)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Solana,
+        ),
       );
       expect(result.current).toEqual(null);
     });
@@ -63,22 +59,18 @@ describe("useAddFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(
-        () =>
-          useAddFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Solana,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useAddFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Solana,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -96,22 +88,18 @@ describe("useAddFeesEstimationQuery", () => {
     });
 
     it("should return valid estimation for Solana only add", async () => {
-      const { result } = renderHook(
-        () =>
-          useAddFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Solana,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useAddFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Solana,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -119,22 +107,18 @@ describe("useAddFeesEstimationQuery", () => {
     });
 
     it("should return eth estimation for Ethereum lpTarget", async () => {
-      const { result } = renderHook(
-        () =>
-          useAddFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Ethereum,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useAddFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Ethereum,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0.021));
@@ -142,22 +126,18 @@ describe("useAddFeesEstimationQuery", () => {
     });
 
     it("should return bsc estimation for Bsc lpTarget", async () => {
-      const { result } = renderHook(
-        () =>
-          useAddFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Bsc,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useAddFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Bsc,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -165,22 +145,18 @@ describe("useAddFeesEstimationQuery", () => {
     });
 
     it("should return valid estimation for mixed input amounts", async () => {
-      const { result } = renderHook(
-        () =>
-          useAddFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(100)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(100)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(101)),
-              Amount.fromHuman(BSC_USDT, new Decimal(101)),
-            ],
-            EcosystemId.Bsc,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useAddFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(100)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(100)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(101)),
+            Amount.fromHuman(BSC_USDT, new Decimal(101)),
+          ],
+          EcosystemId.Bsc,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0.0266));

--- a/apps/ui/src/hooks/swim/useIsEvmGasPriceLoading.test.tsx
+++ b/apps/ui/src/hooks/swim/useIsEvmGasPriceLoading.test.tsx
@@ -1,10 +1,8 @@
-import { renderHook } from "@testing-library/react-hooks";
 import Decimal from "decimal.js";
 import { useQueryClient } from "react-query";
 
 import { EcosystemId } from "../../config";
-import { AppContext } from "../../contexts";
-import { mockOf } from "../../testUtils";
+import { mockOf, renderHookWithAppContext } from "../../testUtils";
 
 import { useGasPriceQuery } from "./useGasPriceQuery";
 import { useIsEvmGasPriceLoading } from "./useIsEvmGasPriceLoading";
@@ -19,9 +17,7 @@ const useGasPriceQueryMock = mockOf(useGasPriceQuery);
 describe("useAddFeesEstimationQuery", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   describe("loading", () => {
@@ -30,9 +26,9 @@ describe("useAddFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(() => useIsEvmGasPriceLoading([]), {
-        wrapper: AppContext,
-      });
+      const { result } = renderHookWithAppContext(() =>
+        useIsEvmGasPriceLoading([]),
+      );
       expect(result.current).toEqual(false);
     });
 
@@ -42,11 +38,8 @@ describe("useAddFeesEstimationQuery", () => {
           ? { isLoading: true, data: undefined }
           : { isLoading: false, data: new Decimal(5e-9) },
       );
-      const { result } = renderHook(
-        () => useIsEvmGasPriceLoading([EcosystemId.Ethereum]),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useIsEvmGasPriceLoading([EcosystemId.Ethereum]),
       );
       expect(result.current).toEqual(true);
     });
@@ -59,11 +52,8 @@ describe("useAddFeesEstimationQuery", () => {
           ? { isLoading: false, data: new Decimal(5e-9) }
           : { isLoading: true, data: undefined },
       );
-      const { result } = renderHook(
-        () => useIsEvmGasPriceLoading([EcosystemId.Ethereum]),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useIsEvmGasPriceLoading([EcosystemId.Ethereum]),
       );
       expect(result.current).toEqual(false);
     });
@@ -73,17 +63,13 @@ describe("useAddFeesEstimationQuery", () => {
         isLoading: false,
         data: new Decimal(5e-9),
       });
-      const { result } = renderHook(
-        () =>
-          useIsEvmGasPriceLoading([
-            EcosystemId.Ethereum,
-            EcosystemId.Bsc,
-            EcosystemId.Polygon,
-            EcosystemId.Avalanche,
-          ]),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useIsEvmGasPriceLoading([
+          EcosystemId.Ethereum,
+          EcosystemId.Bsc,
+          EcosystemId.Polygon,
+          EcosystemId.Avalanche,
+        ]),
       );
       expect(result.current).toEqual(false);
     });

--- a/apps/ui/src/hooks/swim/useRemoveFeesEstimationQuery.test.ts
+++ b/apps/ui/src/hooks/swim/useRemoveFeesEstimationQuery.test.ts
@@ -1,11 +1,13 @@
-import { renderHook } from "@testing-library/react-hooks";
 import Decimal from "decimal.js";
 import { useQueryClient } from "react-query";
 
 import { EcosystemId } from "../../config";
-import { AppContext } from "../../contexts";
 import { Amount } from "../../models";
-import { findLocalnetTokenById, mockOf } from "../../testUtils";
+import {
+  findLocalnetTokenById,
+  mockOf,
+  renderHookWithAppContext,
+} from "../../testUtils";
 
 import { useGasPriceQuery } from "./useGasPriceQuery";
 import { useRemoveFeesEstimationQuery } from "./useRemoveFeesEstimationQuery";
@@ -27,9 +29,7 @@ const BSC_USDT = findLocalnetTokenById("localnet-bsc-usdt");
 describe("useRemoveFeesEstimationQuery", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   describe("loading", () => {
@@ -38,22 +38,18 @@ describe("useRemoveFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(
-        () =>
-          useRemoveFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(99)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Solana,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useRemoveFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(99)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Solana,
+        ),
       );
       expect(result.current).toEqual(null);
     });
@@ -63,22 +59,18 @@ describe("useRemoveFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(
-        () =>
-          useRemoveFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Solana,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useRemoveFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Solana,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -96,22 +88,18 @@ describe("useRemoveFeesEstimationQuery", () => {
     });
 
     it("should return solana estimation for Solana USDC single remove", async () => {
-      const { result } = renderHook(
-        () =>
-          useRemoveFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Solana,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useRemoveFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Solana,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -119,22 +107,18 @@ describe("useRemoveFeesEstimationQuery", () => {
     });
 
     it("should return eth estimation for Ethereum USDC single remove", async () => {
-      const { result } = renderHook(
-        () =>
-          useRemoveFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(0)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(0)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Ethereum,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useRemoveFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(0)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(0)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Ethereum,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0.0343));
@@ -142,22 +126,18 @@ describe("useRemoveFeesEstimationQuery", () => {
     });
 
     it("should return bsc estimation for Bsc single remove", async () => {
-      const { result } = renderHook(
-        () =>
-          useRemoveFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(0)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(99)),
-              Amount.fromHuman(BSC_USDT, new Decimal(0)),
-            ],
-            EcosystemId.Bsc,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useRemoveFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(0)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(0)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(99)),
+            Amount.fromHuman(BSC_USDT, new Decimal(0)),
+          ],
+          EcosystemId.Bsc,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -165,22 +145,18 @@ describe("useRemoveFeesEstimationQuery", () => {
     });
 
     it("should return valid estimation for mixed input amounts", async () => {
-      const { result } = renderHook(
-        () =>
-          useRemoveFeesEstimationQuery(
-            [
-              Amount.fromHuman(SOLANA_USDC, new Decimal(100)),
-              Amount.fromHuman(SOLANA_USDT, new Decimal(100)),
-              Amount.fromHuman(ETHEREUM_USDC, new Decimal(100)),
-              Amount.fromHuman(ETHEREUM_USDT, new Decimal(100)),
-              Amount.fromHuman(BSC_BUSD, new Decimal(100)),
-              Amount.fromHuman(BSC_USDT, new Decimal(100)),
-            ],
-            EcosystemId.Bsc,
-          ),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useRemoveFeesEstimationQuery(
+          [
+            Amount.fromHuman(SOLANA_USDC, new Decimal(100)),
+            Amount.fromHuman(SOLANA_USDT, new Decimal(100)),
+            Amount.fromHuman(ETHEREUM_USDC, new Decimal(100)),
+            Amount.fromHuman(ETHEREUM_USDT, new Decimal(100)),
+            Amount.fromHuman(BSC_BUSD, new Decimal(100)),
+            Amount.fromHuman(BSC_USDT, new Decimal(100)),
+          ],
+          EcosystemId.Bsc,
+        ),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0.042));

--- a/apps/ui/src/hooks/swim/useSwapFeesEstimationQuery.test.ts
+++ b/apps/ui/src/hooks/swim/useSwapFeesEstimationQuery.test.ts
@@ -1,10 +1,12 @@
-import { renderHook } from "@testing-library/react-hooks";
 import Decimal from "decimal.js";
 import { useQueryClient } from "react-query";
 
 import { EcosystemId } from "../../config";
-import { AppContext } from "../../contexts";
-import { findLocalnetTokenById, mockOf } from "../../testUtils";
+import {
+  findLocalnetTokenById,
+  mockOf,
+  renderHookWithAppContext,
+} from "../../testUtils";
 
 import { useGasPriceQuery } from "./useGasPriceQuery";
 import { useSwapFeesEstimationQuery } from "./useSwapFeesEstimationQuery";
@@ -24,9 +26,7 @@ const BSC_BUSD = findLocalnetTokenById("localnet-bsc-busd");
 describe("useSwapFeesEstimationQuery", () => {
   beforeEach(() => {
     // Reset queryClient cache, otherwise test might return previous value
-    renderHook(() => useQueryClient().clear(), {
-      wrapper: AppContext,
-    });
+    renderHookWithAppContext(() => useQueryClient().clear());
   });
 
   describe("loading", () => {
@@ -35,11 +35,8 @@ describe("useSwapFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(
-        () => useSwapFeesEstimationQuery(SOLANA_USDT, ETHEREUM_USDT),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useSwapFeesEstimationQuery(SOLANA_USDT, ETHEREUM_USDT),
       );
       expect(result.current).toEqual(null);
     });
@@ -49,11 +46,8 @@ describe("useSwapFeesEstimationQuery", () => {
         isLoading: true,
         data: undefined,
       });
-      const { result } = renderHook(
-        () => useSwapFeesEstimationQuery(SOLANA_USDC, SOLANA_USDT),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useSwapFeesEstimationQuery(SOLANA_USDC, SOLANA_USDT),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -71,11 +65,8 @@ describe("useSwapFeesEstimationQuery", () => {
     });
 
     it("should return fixed fee for Solana only swap", async () => {
-      const { result } = renderHook(
-        () => useSwapFeesEstimationQuery(SOLANA_USDC, SOLANA_USDT),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useSwapFeesEstimationQuery(SOLANA_USDC, SOLANA_USDT),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -83,11 +74,8 @@ describe("useSwapFeesEstimationQuery", () => {
     });
 
     it("should return fee for Solana => Ethereum", async () => {
-      const { result } = renderHook(
-        () => useSwapFeesEstimationQuery(SOLANA_USDC, ETHEREUM_USDT),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useSwapFeesEstimationQuery(SOLANA_USDC, ETHEREUM_USDT),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0.021));
@@ -95,11 +83,8 @@ describe("useSwapFeesEstimationQuery", () => {
     });
 
     it("should return fee for Solana => BSC", async () => {
-      const { result } = renderHook(
-        () => useSwapFeesEstimationQuery(SOLANA_USDC, BSC_BUSD),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useSwapFeesEstimationQuery(SOLANA_USDC, BSC_BUSD),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0));
@@ -107,11 +92,8 @@ describe("useSwapFeesEstimationQuery", () => {
     });
 
     it("should return fee for Ethereum => BSC", async () => {
-      const { result } = renderHook(
-        () => useSwapFeesEstimationQuery(ETHEREUM_USDT, BSC_BUSD),
-        {
-          wrapper: AppContext,
-        },
+      const { result } = renderHookWithAppContext(() =>
+        useSwapFeesEstimationQuery(ETHEREUM_USDT, BSC_BUSD),
       );
       expect(result.current?.solana).toEqual(new Decimal(0.01));
       expect(result.current?.ethereum).toEqual(new Decimal(0.0133));

--- a/apps/ui/src/testUtils.ts
+++ b/apps/ui/src/testUtils.ts
@@ -1,9 +1,21 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { renderHook } from "@testing-library/react-hooks";
+
 import type { TokenSpec } from "./config";
 import { Env, tokens } from "./config";
+import { AppContext } from "./contexts";
 
 export const mockOf = <T>(v: (...any: any) => T): jest.Mock<Partial<T>> =>
   v as unknown as jest.Mock<Partial<T>>;
 
 export const findLocalnetTokenById = (tokenId: string): TokenSpec =>
   tokens[Env.Localnet].find(({ id }) => id === tokenId)!;
+
+export const renderHookWithAppContext: typeof renderHook = (
+  callback,
+  options = {},
+) =>
+  renderHook(callback, {
+    ...options,
+    wrapper: AppContext,
+  });


### PR DESCRIPTION
Adding a new testUtil, so that we don't need to include AppContext every time

```
export const renderHookWithAppContext: typeof renderHook = (
  callback,
  options = {},
) =>
  renderHook(callback, {
    ...options,
    wrapper: AppContext,
  });
```