### PR TITLE
Update interaction hook to use object instead of id

### DIFF
--- a/apps/ui/src/hooks/interaction/useRequiredEcosystemsForInteraction.test.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredEcosystemsForInteraction.test.ts
@@ -7,18 +7,9 @@ import {
   SOL_USDC_TO_ETH_USDC_SWAP,
   SOL_USDC_TO_SOL_USDT_SWAP,
 } from "../../fixtures/swim/interactions";
-import { mockOf, renderHookWithAppContext } from "../../testUtils";
+import { renderHookWithAppContext } from "../../testUtils";
 
-import { useInteraction } from "./useInteraction";
 import { useRequiredEcosystemsForInteraction } from "./useRequiredEcosystemsForInteraction";
-
-jest.mock("./useInteraction", () => ({
-  ...jest.requireActual("./useInteraction"),
-  useInteraction: jest.fn(),
-}));
-
-// Make typescript happy with jest
-const useInteractionMock = mockOf(useInteraction);
 
 describe("useRequiredEcosystemsForInteraction", () => {
   beforeEach(() => {
@@ -27,9 +18,8 @@ describe("useRequiredEcosystemsForInteraction", () => {
   });
 
   it("should return required ecosystems for ETH to SOL Swap", async () => {
-    useInteractionMock.mockReturnValue(ETH_USDC_TO_SOL_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredEcosystemsForInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
+      useRequiredEcosystemsForInteraction(ETH_USDC_TO_SOL_USDC_SWAP),
     );
     expect(result.current).toEqual(
       new Set([EcosystemId.Ethereum, EcosystemId.Solana]),
@@ -37,9 +27,8 @@ describe("useRequiredEcosystemsForInteraction", () => {
   });
 
   it("should return required ecosystems for SOL to ETH Swap", async () => {
-    useInteractionMock.mockReturnValue(SOL_USDC_TO_ETH_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredEcosystemsForInteraction(SOL_USDC_TO_ETH_USDC_SWAP.id),
+      useRequiredEcosystemsForInteraction(SOL_USDC_TO_ETH_USDC_SWAP),
     );
     expect(result.current).toEqual(
       new Set([EcosystemId.Ethereum, EcosystemId.Solana]),
@@ -47,17 +36,15 @@ describe("useRequiredEcosystemsForInteraction", () => {
   });
 
   it("should return required ecosystems for SOL to SOL Swap", async () => {
-    useInteractionMock.mockReturnValue(SOL_USDC_TO_SOL_USDT_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredEcosystemsForInteraction(SOL_USDC_TO_SOL_USDT_SWAP.id),
+      useRequiredEcosystemsForInteraction(SOL_USDC_TO_SOL_USDT_SWAP),
     );
     expect(result.current).toEqual(new Set([EcosystemId.Solana]));
   });
 
   it("should return required ecosystems for BSC to ETH Swap", async () => {
-    useInteractionMock.mockReturnValue(BSC_USDT_TO_ETH_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredEcosystemsForInteraction(BSC_USDT_TO_ETH_USDC_SWAP.id),
+      useRequiredEcosystemsForInteraction(BSC_USDT_TO_ETH_USDC_SWAP),
     );
     expect(result.current).toEqual(
       new Set([EcosystemId.Ethereum, EcosystemId.Solana, EcosystemId.Bsc]),

--- a/apps/ui/src/hooks/interaction/useRequiredEcosystemsForInteraction.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredEcosystemsForInteraction.ts
@@ -1,13 +1,11 @@
 import type { EcosystemId } from "../../config";
 import { useConfig } from "../../contexts";
+import type { Interaction } from "../../models";
 import { getRequiredEcosystems } from "../../models";
 
-import { useInteraction } from "./useInteraction";
-
 export const useRequiredEcosystemsForInteraction = (
-  interactionId: string,
+  interaction: Interaction,
 ): ReadonlySet<EcosystemId> => {
   const { tokens } = useConfig();
-  const interaction = useInteraction(interactionId);
   return getRequiredEcosystems(tokens, interaction);
 };

--- a/apps/ui/src/hooks/interaction/useRequiredPoolsForInteraction.test.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredPoolsForInteraction.test.ts
@@ -10,20 +10,14 @@ import {
 } from "../../fixtures/swim/interactions";
 import { mockOf, renderHookWithAppContext } from "../../testUtils";
 
-import { useInteraction } from "./useInteraction";
 import { useRequiredPoolsForInteraction } from "./useRequiredPoolsForInteraction";
 
 jest.mock("../../contexts", () => ({
   ...jest.requireActual("../../contexts"),
   useConfig: jest.fn(),
 }));
-jest.mock("./useInteraction", () => ({
-  ...jest.requireActual("./useInteraction"),
-  useInteraction: jest.fn(),
-}));
 
 // Make typescript happy with jest
-const useInteractionMock = mockOf(useInteraction);
 const useConfigMock = mockOf(useConfig);
 
 describe("useRequiredPoolsForInteraction", () => {
@@ -34,33 +28,29 @@ describe("useRequiredPoolsForInteraction", () => {
   });
 
   it("should return hexapool for ETH USDC to SOL USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(ETH_USDC_TO_SOL_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredPoolsForInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
+      useRequiredPoolsForInteraction(ETH_USDC_TO_SOL_USDC_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual(["hexapool"]);
   });
 
   it("should return hexapool for SOL USDC to ETH USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(SOL_USDC_TO_ETH_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredPoolsForInteraction(SOL_USDC_TO_ETH_USDC_SWAP.id),
+      useRequiredPoolsForInteraction(SOL_USDC_TO_ETH_USDC_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual(["hexapool"]);
   });
 
   it("should return hexapool for SOL USDC to SOL USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(SOL_USDC_TO_SOL_USDT_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredPoolsForInteraction(SOL_USDC_TO_SOL_USDT_SWAP.id),
+      useRequiredPoolsForInteraction(SOL_USDC_TO_SOL_USDT_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual(["hexapool"]);
   });
 
   it("should return hexapool for BSC USDT to ETH USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(BSC_USDT_TO_ETH_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredPoolsForInteraction(BSC_USDT_TO_ETH_USDC_SWAP.id),
+      useRequiredPoolsForInteraction(BSC_USDT_TO_ETH_USDC_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual(["hexapool"]);
   });

--- a/apps/ui/src/hooks/interaction/useRequiredPoolsForInteraction.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredPoolsForInteraction.ts
@@ -1,13 +1,11 @@
 import type { PoolSpec } from "../../config";
 import { useConfig } from "../../contexts";
+import type { Interaction } from "../../models";
 import { getRequiredPools } from "../../models";
 
-import { useInteraction } from "./useInteraction";
-
 export const useRequiredPoolsForInteraction = (
-  interactionId: string,
+  interaction: Interaction,
 ): readonly PoolSpec[] => {
   const { pools } = useConfig();
-  const interaction = useInteraction(interactionId);
   return getRequiredPools(pools, interaction);
 };

--- a/apps/ui/src/hooks/interaction/useRequiredTokensForInteraction.test.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredTokensForInteraction.test.ts
@@ -10,20 +10,14 @@ import {
 } from "../../fixtures/swim/interactions";
 import { mockOf, renderHookWithAppContext } from "../../testUtils";
 
-import { useInteraction } from "./useInteraction";
 import { useRequiredTokensForInteraction } from "./useRequiredTokensForInteraction";
 
 jest.mock("../../contexts", () => ({
   ...jest.requireActual("../../contexts"),
   useConfig: jest.fn(),
 }));
-jest.mock("./useInteraction", () => ({
-  ...jest.requireActual("./useInteraction"),
-  useInteraction: jest.fn(),
-}));
 
 // Make typescript happy with jest
-const useInteractionMock = mockOf(useInteraction);
 const useConfigMock = mockOf(useConfig);
 
 describe("useRequiredTokensForInteraction", () => {
@@ -34,9 +28,8 @@ describe("useRequiredTokensForInteraction", () => {
   });
 
   it("should return required tokens for ETH USDC to SOL USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(ETH_USDC_TO_SOL_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredTokensForInteraction(ETH_USDC_TO_SOL_USDC_SWAP.id),
+      useRequiredTokensForInteraction(ETH_USDC_TO_SOL_USDC_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual([
       "localnet-ethereum-usdc",
@@ -45,9 +38,8 @@ describe("useRequiredTokensForInteraction", () => {
   });
 
   it("should return required tokens for SOL USDC to ETH USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(SOL_USDC_TO_ETH_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredTokensForInteraction(SOL_USDC_TO_ETH_USDC_SWAP.id),
+      useRequiredTokensForInteraction(SOL_USDC_TO_ETH_USDC_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual([
       "localnet-solana-usdc",
@@ -56,9 +48,8 @@ describe("useRequiredTokensForInteraction", () => {
   });
 
   it("should return required tokens for SOL USDC to SOL USDT Swap", async () => {
-    useInteractionMock.mockReturnValue(SOL_USDC_TO_SOL_USDT_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredTokensForInteraction(SOL_USDC_TO_SOL_USDT_SWAP.id),
+      useRequiredTokensForInteraction(SOL_USDC_TO_SOL_USDT_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual([
       "localnet-solana-usdc",
@@ -67,9 +58,8 @@ describe("useRequiredTokensForInteraction", () => {
   });
 
   it("should return required tokens for BSC USDT to ETH USDC Swap", async () => {
-    useInteractionMock.mockReturnValue(BSC_USDT_TO_ETH_USDC_SWAP);
     const { result } = renderHookWithAppContext(() =>
-      useRequiredTokensForInteraction(BSC_USDT_TO_ETH_USDC_SWAP.id),
+      useRequiredTokensForInteraction(BSC_USDT_TO_ETH_USDC_SWAP),
     );
     expect(result.current.map(({ id }) => id)).toEqual([
       "localnet-bsc-usdt",

--- a/apps/ui/src/hooks/interaction/useRequiredTokensForInteraction.ts
+++ b/apps/ui/src/hooks/interaction/useRequiredTokensForInteraction.ts
@@ -1,16 +1,15 @@
 import type { TokenSpec } from "../../config";
 import { useConfig } from "../../contexts";
+import type { Interaction } from "../../models";
 import { getRequiredTokens, getTokensByPool } from "../../models";
 
-import { useInteraction } from "./useInteraction";
 import { useRequiredPoolsForInteraction } from "./useRequiredPoolsForInteraction";
 
 export const useRequiredTokensForInteraction = (
-  interactionId: string,
+  interaction: Interaction,
 ): readonly TokenSpec[] => {
   const config = useConfig();
   const tokensByPoolId = getTokensByPool(config);
-  const interaction = useInteraction(interactionId);
-  const pools = useRequiredPoolsForInteraction(interactionId);
+  const pools = useRequiredPoolsForInteraction(interaction);
   return getRequiredTokens(tokensByPoolId, pools, interaction);
 };

--- a/apps/ui/src/hooks/interaction/useTxsForInteractionQuery.ts
+++ b/apps/ui/src/hooks/interaction/useTxsForInteractionQuery.ts
@@ -6,6 +6,7 @@ import { useEnvironment } from "../../contexts";
 import type { Tx } from "../../models";
 
 import { useEvmTxsForInteractionQuery } from "./useEvmTxsForInteractionQuery";
+import { useInteraction } from "./useInteraction";
 import { useRequiredEcosystemsForInteraction } from "./useRequiredEcosystemsForInteraction";
 import { useSolanaTxsForInteractionQuery } from "./useSolanaTxsForInteractionQuery";
 
@@ -13,6 +14,7 @@ export const useTxsForInteractionQuery = (
   interactionId: string,
 ): UseQueryResult<readonly Tx[], Error> => {
   const { env } = useEnvironment();
+  const interaction = useInteraction(interactionId);
   const txQueries = {
     [EcosystemId.Solana]: useSolanaTxsForInteractionQuery(interactionId),
     [EcosystemId.Ethereum]: useEvmTxsForInteractionQuery(
@@ -37,7 +39,7 @@ export const useTxsForInteractionQuery = (
     [EcosystemId.Acala]: useQuery({ enabled: false }),
   };
   const requiredEcosystems = [
-    ...useRequiredEcosystemsForInteraction(interactionId).values(),
+    ...useRequiredEcosystemsForInteraction(interaction).values(),
   ];
   return useQuery(
     [env, "txsForInteraction", interactionId],


### PR DESCRIPTION
Since the new interaction state in https://github.com/swim-io/swim/pull/46/files
will also include the interaction object and persist with Zustand

The hook `useInteractions(id)` might be deprecated, so changing all dependent hook to take `interaction: Interaction` as param.

Test:
```
 PASS  src/models/wormhole/solana.test.ts (6.289 s)
 PASS  src/models/amount.test.ts
 PASS  src/models/swim/transfer.test.ts (6.604 s)
 PASS  src/hooks/swim/useRemoveFeesEstimationQuery.test.ts (6.653 s)
 PASS  src/hooks/swim/useAddFeesEstimationQuery.test.ts (6.653 s)
 PASS  src/core/store/tests/useNotification.test.ts
 PASS  src/models/swim/steps.test.ts (7.772 s)
 PASS  src/hooks/swim/useIsEvmGasPriceLoading.test.tsx
 PASS  src/hooks/interaction/useRequiredTokensForInteraction.test.ts
 PASS  src/hooks/swim/useSwapFeesEstimationQuery.test.ts
 PASS  src/models/crossEcosystem/tx.test.ts
 PASS  src/config/tokens.test.ts
 PASS  src/models/swim/decimal.test.ts
 PASS  src/config/chains.test.ts
 PASS  src/config/pools.test.ts
 PASS  src/models/swim/pool.test.ts
 PASS  src/hooks/interaction/useInteraction.test.ts
 PASS  src/models/solana/utils.test.ts
 PASS  src/hooks/solana/useSolBalanceQuery.test.ts
 PASS  src/models/wormhole/utils.test.ts
 PASS  src/hooks/interaction/useRequiredEcosystemsForInteraction.test.ts
 PASS  src/hooks/interaction/useRequiredPoolsForInteraction.test.ts
 PASS  src/errors/sentry.test.ts
 PASS  src/hooks/utils/usePrevious.test.ts
 PASS  src/models/swim/poolMath.test.ts
 PASS  src/models/swim/ampFactor.test.ts
 PASS  src/amounts.test.ts
 PASS  src/hooks/browser/useTitle.test.ts
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.

Test Suites: 28 passed, 28 total
Tests:       17 todo, 246 passed, 263 total
Snapshots:   0 total
Time:        10.651 s, estimated 37 s
Ran all test suites.
```