### PR TITLE
fix(ui): Fix verify script to check format

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --fix \"./src/**/*.{ts,tsx}\"",
     "typecheck": "tsc",
     "types:generate": "typechain --target=ethers-v5 --out-dir=src/contracts/ abi/*.json",
-    "verify": "yarn typecheck && yarn lint && yarn test --watchAll=false && yarn format",
+    "verify": "yarn typecheck && yarn lint && yarn test --watchAll=false && yarn format:check",
     "storybook": "DISABLE_ESLINT_PLUGIN=true start-storybook -p 6006"
   },
   "browserslist": {


### PR DESCRIPTION
Replace `yarn format` which uses the `--write` flag with `yarn format:check` in yarn verify script