### PR TITLE
test(ui): Mock Solana websocket client during tests

### DIFF
--- a/apps/ui/src/setupTests.ts
+++ b/apps/ui/src/setupTests.ts
@@ -6,7 +6,6 @@ import "@testing-library/jest-dom";
 
 // mock Solana websocket connection
 jest.mock("rpc-websockets", () => ({
-  __esModule: true,
   Client: class MockRpcWebsocketClient {
     on(): null {
       return null;


### PR DESCRIPTION
These websockets connections are a side effect of AppContext which currently always initialises a solana connection.

By mocking the underlying library used by `solana/web3.js` we won't be initialising real connections any more.

After this change this message no longer appears:

```
A worker process has failed to exit gracefully and has been force exited. 
This is likely caused by tests leaking due to improper teardown. 
Try running with --detectOpenHandles to find leaks.
```

See this [slack thread](https://exsphere.slack.com/archives/C02EPGU5J4S/p1653995757114339) for more