### PR TITLE
fix(ui): Fix missing spl token accounts for newly created account

### DIFF
--- a/apps/ui/src/hooks/interaction/usePrepareSplTokenAccountMutation.ts
+++ b/apps/ui/src/hooks/interaction/usePrepareSplTokenAccountMutation.ts
@@ -1,9 +1,10 @@
-import { useMutation } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 
 import { useSolanaConnection, useSolanaWallet } from "../../contexts";
 import { selectGetInteractionState } from "../../core/selectors";
 import { useInteractionState } from "../../core/store";
 import { createSplTokenAccount } from "../../models";
+import { getSplTokenAccountsQueryKey } from "../solana";
 
 export const usePrepareSplTokenAccountMutation = () => {
   const solanaConnection = useSolanaConnection();
@@ -12,6 +13,7 @@ export const usePrepareSplTokenAccountMutation = () => {
     (state) => state.updateInteractionState,
   );
   const getInteractionState = useInteractionState(selectGetInteractionState);
+  const queryClient = useQueryClient();
 
   return useMutation(async (interactionId: string) => {
     if (wallet === null) {
@@ -23,31 +25,37 @@ export const usePrepareSplTokenAccountMutation = () => {
     }
     const { interaction, requiredSplTokenAccounts } =
       getInteractionState(interactionId);
-    await Promise.all(
-      Object.entries(requiredSplTokenAccounts).map(
-        async ([mint, accountState]) => {
-          // Account exist, skip creation step
-          if (accountState.account !== null) {
-            return;
-          }
-          const creationTxId = await createSplTokenAccount(
-            solanaConnection,
-            wallet,
-            mint,
-          );
-          await solanaConnection.confirmTx(creationTxId);
-          const account = await solanaConnection.getTokenAccountWithRetry(
-            mint,
-            solanaAddress,
-          );
 
-          // Update interactionState
-          updateInteractionState(interaction.id, (draft) => {
-            draft.requiredSplTokenAccounts[mint].account = account;
-            draft.requiredSplTokenAccounts[mint].txId = creationTxId;
-          });
-        },
-      ),
+    const missingAccountMints = Object.entries(requiredSplTokenAccounts)
+      .filter(([mint, accountState]) => !accountState.isExistingAccount)
+      .map(([mint, accountState]) => mint);
+    await Promise.all(
+      missingAccountMints.map(async (mint) => {
+        const creationTxId = await createSplTokenAccount(
+          solanaConnection,
+          wallet,
+          mint,
+        );
+        await solanaConnection.confirmTx(creationTxId);
+        const account = await solanaConnection.getTokenAccountWithRetry(
+          mint,
+          solanaAddress,
+        );
+
+        // Update interactionState
+        updateInteractionState(interaction.id, (draft) => {
+          draft.requiredSplTokenAccounts[mint].account = account;
+          draft.requiredSplTokenAccounts[mint].txId = creationTxId;
+        });
+      }),
     );
+
+    if (missingAccountMints.length > 0) {
+      const splTokenAccountsQueryKey = getSplTokenAccountsQueryKey(
+        interaction.env,
+        solanaAddress,
+      );
+      await queryClient.refetchQueries(splTokenAccountsQueryKey);
+    }
   });
 };

--- a/apps/ui/src/hooks/solana/useSplTokenAccountsQuery.ts
+++ b/apps/ui/src/hooks/solana/useSplTokenAccountsQuery.ts
@@ -4,9 +4,15 @@ import { PublicKey } from "@solana/web3.js";
 import type { UseQueryResult } from "react-query";
 import { useQuery } from "react-query";
 
+import type { Env } from "../../config";
 import { useSolanaConnection, useSolanaWallet } from "../../contexts";
 import { useEnvironment } from "../../core/store";
 import { deserializeTokenAccount } from "../../models";
+
+export const getSplTokenAccountsQueryKey = (
+  env: Env,
+  address: string | null,
+) => ["tokenAccounts", env, address];
 
 export const useSplTokenAccountsQuery = (
   owner?: string,
@@ -16,7 +22,7 @@ export const useSplTokenAccountsQuery = (
   const { address: userAddress } = useSolanaWallet();
   const address = owner ?? userAddress;
 
-  const queryKey = ["tokenAccounts", env, address];
+  const queryKey = getSplTokenAccountsQueryKey(env, address);
   const query = useQuery<readonly TokenAccount[], Error>(queryKey, async () => {
     if (address === null) {
       return [];


### PR DESCRIPTION
## Description

A few sentry error related to missing Spl token account.
https://sentry.io/organizations/swim/issues/3336912404/?query=is%3Aunresolved&sort=new&statsPeriod=24h
https://sentry.io/organizations/swim/issues/3288245677/?query=is%3Aunresolved&sort=new&statsPeriod=24h
https://sentry.io/organizations/swim/issues/3353618427/?query=is%3Aunresolved&sort=new&statsPeriod=24h

## Root cause

After created Spl token accounts, we didn't refetch the query, so the following mutation didn't get the newly created accounts.

## Solution

After created spl token account in `usePrepareSplTokenAccountMutation`, force a refetch so that the new accounts will be available in the following mutations.

## Post Review Checklist

1. test on Devnet
2. use new SOL wallet address, get some test token from https://solfaucet.com/
3. Swap with sending some coin to the new SOL wallet
4. debug with react-query devtool
5. you will see after `Prepare SPL token accounts` steps, the query are refetched and new accounts are showing up

https://user-images.githubusercontent.com/101085251/174053984-810d9c6f-9364-4cb2-a3c6-0c3b32b3c158.mov


