### PR TITLE
Don't use isExistingAccount since its not updated

### DIFF
--- a/apps/ui/src/hooks/interaction/usePrepareSplTokenAccountMutation.ts
+++ b/apps/ui/src/hooks/interaction/usePrepareSplTokenAccountMutation.ts
@@ -27,8 +27,8 @@ export const usePrepareSplTokenAccountMutation = () => {
       getInteractionState(interactionId);
 
     const missingAccountMints = Object.entries(requiredSplTokenAccounts)
-      .filter(([mint, accountState]) => !accountState.isExistingAccount)
-      .map(([mint, accountState]) => mint);
+      .filter(([_mint, accountState]) => accountState.account === null)
+      .map(([mint, _accountState]) => mint);
     await Promise.all(
       missingAccountMints.map(async (mint) => {
         const creationTxId = await createSplTokenAccount(


### PR DESCRIPTION
## Description
This PR https://github.com/swim-io/swim/pull/114 creates the following bug:

Users occasionally receive a "transaction simulation failed 0x0" after a wormhole completion. I believe this tx is the token account creation, and it is failing on "already exists". PR 114 checks whether the token account exists using `isExistingAccount`, but this field is NEVER updated, and prior to the change, we used `account === null`. Reverted check to use `account === null`. We should double check our `isExistingAccount` usage.


Slack discussion: https://exsphere.slack.com/archives/C02PVCS2PKQ/p1655552158445179
Old tx simulation ticket: https://www.notion.so/exsphere/Transaction-simulation-failed-68a363d32b0942e2b7b1f8f6904dc33b

## PR Checklist

<!-- Please check if your PR fulfills the following requirements:  -->

- [ ] Tests for the changes have been added (optional but recommended)
- [ ] Docs have been added / updated (optional)
- [ ] The relevant Github Project (and/or label) has been assigned (applies only when there is one)
- [x] Preview deployment is not broken. Please visit the Cloudflare pages preview URL

## Post Review Checklist

- [ ] If your PR changes are significant please share the preview deployment URL with the product team in Slack's #product-swim for some manual testing _before_ merging.

## Is there a ticket for this change? If yes, please paste the notion link below

Notion link: N/A
