### PR TITLE
Call getSignature before confirmTx due to Solana lib issues

### DIFF
--- a/apps/ui/src/models/solana/SolanaConnection.ts
+++ b/apps/ui/src/models/solana/SolanaConnection.ts
@@ -114,9 +114,9 @@ export class SolanaConnection {
     // call getSignature() beforehand to circumvent.
     // TODO: Remove signature code once issue is addressed.
     // https://github.com/solana-labs/solana/issues/25955
-    const SignatureStatus = await this.getSigStatusToSigResult(txId);
-    if (SignatureStatus) {
-      return SignatureStatus;
+    const signatureStatus = await this.getSigStatusToSigResult(txId);
+    if (signatureStatus) {
+      return signatureStatus;
     }
     while (remainingAttempts >= 0) {
       try {
@@ -332,17 +332,14 @@ export class SolanaConnection {
     try {
       const { context, value } = await this.rawConnection.getSignatureStatus(
         txId,
+        { searchTransactionHistory: true },
       );
       if (!value) {
         return null;
       }
       return {
-        context: {
-          slot: context.slot,
-        },
-        value: {
-          err: null,
-        },
+        context,
+        value,
       };
     } catch {
       return null;


### PR DESCRIPTION
## Description

confirmTransaction() always fails if the signature is processed, due to how to library is written (see this [issue](https://github.com/solana-labs/solana-web3.js/issues/1107)). We call `getSignature()`, as recommended by issue post.

Slack & sentry links:
https://exsphere.slack.com/archives/C02PVCS2PKQ/p1655646589773819
https://sentry.io/organizations/swim/issues/3304264706/?query=is%3Aunresolved
## PR Checklist

<!-- Please check if your PR fulfills the following requirements:  -->

- [x] The relevant Github Project (and/or label) has been assigned (applies only when there is one)
- [x] Preview deployment is not broken. Please visit the Cloudflare pages preview URL