### PR TITLE
Always convert wei to ethers

### DIFF
--- a/apps/ui/src/hooks/swim/useGasPriceQuery.ts
+++ b/apps/ui/src/hooks/swim/useGasPriceQuery.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js";
+import { utils as ethersUtils } from "ethers";
 import type { UseQueryResult } from "react-query";
 import { useQuery } from "react-query";
 
@@ -17,12 +18,10 @@ export const useGasPriceQuery = (
   return useQuery(
     ["gasPrice", env, evmEcosystemId],
     async () => {
-      // The BSC connection still returns the gas price in "wei" (ie 1e-18 BNB)
-      // even though this is not a valid unit of BNB
       const gasPriceInWei = await connection.provider.getGasPrice();
       const gasPriceInNativeCurrency = new Decimal(
-        gasPriceInWei.toString(),
-      ).mul(1e-18);
+        ethersUtils.formatUnits(gasPriceInWei),
+      );
       // Multiply by 1.1 to give some margin
       return gasPriceInNativeCurrency.mul(1.1);
     },

--- a/apps/ui/src/models/evm/EvmConnection.ts
+++ b/apps/ui/src/models/evm/EvmConnection.ts
@@ -283,8 +283,8 @@ export class EvmConnection {
 
   public async getEthBalance(walletAddress: string): Promise<Decimal> {
     try {
-      const balance = await this.provider.getBalance(walletAddress);
-      return new Decimal(balance.toString());
+      const balanceInWei = await this.provider.getBalance(walletAddress);
+      return new Decimal(ethers.utils.formatUnits(balanceInWei));
     } catch {
       return new Decimal(0);
     }


### PR DESCRIPTION
## Description

EVM's JSON RPC returns `getBalance` and gas related queries in wei. Our codebase uses a mix of both units (causing a small, non-malicious bug). This PR standardizes to ethers.

Docs
* https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getbalance
* https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#getgasprice

## PR Checklist

- [ ] Tests for the changes have been added (optional but recommended)
- [x] Docs have been added / updated (optional)
- [x] The relevant Github Project (and/or label) has been assigned (applies only when there is one)
- [x] Preview deployment is not broken. Please visit the Cloudflare pages preview URL
