### PR TITLE
fix(ui): Disable retry when wallet disconnected

### DIFF
--- a/apps/ui/src/components/molecules/InteractionRetryCallout.tsx
+++ b/apps/ui/src/components/molecules/InteractionRetryCallout.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import { selectInteractionError } from "../../core/selectors";
 import { useInteractionState } from "../../core/store";
 import { formatErrorJsx } from "../../errors";
+import { isEveryAddressConnected, useWallets } from "../../hooks";
 import {
   InteractionStatus,
   useHasActiveInteraction,
@@ -61,6 +62,10 @@ export const InteractionRetryCallout: React.FC<Props> = ({
   const resumeInteraction = useResumeInteraction();
   const hasActiveInteraction = useHasActiveInteraction();
   const interactionStatus = useInteractionStatus(interactionState);
+  const wallets = useWallets();
+  const disabled =
+    hasActiveInteraction ||
+    !isEveryAddressConnected(interaction.connectedWallets, wallets);
 
   if (
     interactionStatus === InteractionStatus.Completed ||
@@ -81,7 +86,7 @@ export const InteractionRetryCallout: React.FC<Props> = ({
         <EuiSpacer />
         <RetryOrResumeButton
           title={"Retry"}
-          disabled={hasActiveInteraction}
+          disabled={disabled}
           onClick={() => resumeInteraction(interaction.id)}
         />
       </EuiCallOut>
@@ -91,7 +96,7 @@ export const InteractionRetryCallout: React.FC<Props> = ({
   return (
     <RetryOrResumeButton
       title={"Resume"}
-      disabled={hasActiveInteraction}
+      disabled={disabled}
       onClick={() => resumeInteraction(interaction.id)}
     />
   );


### PR DESCRIPTION
## Description

Disable retry when required wallets disconnected

## PR Checklist

- [x] Tests for the changes have been added (optional but recommended)

- Start a swap
- reject popup
- disconnect wallet, should see retry button disabled
<img width="810" alt="Swap___Swim" src="https://user-images.githubusercontent.com/101085251/176124529-79856b5d-04f9-4d13-a41f-95294082afd2.png">

- [ ] Docs have been added / updated (optional)
- [ ] The relevant Github Project (and/or label) has been assigned (applies only when there is one)

## Post Review Checklist

- [ ] If your PR changes are significant please share the preview deployment URL with the product team in Slack's #product-swim for some manual testing _before_ merging.

## Is there a ticket for this change? If yes, please paste the notion link below

https://www.notion.so/exsphere/33a3ed0734e24872ba8eaa0ddc83230a?v=e50f0fdd3ebf413595e48a9cf4c0d8aa&p=515bd3a0d6b542d382f974b07763b614
