### PR TITLE
fix(ui): disable disconnect button when interaction is progress

### DIFF
--- a/apps/ui/src/components/ConnectButton.tsx
+++ b/apps/ui/src/components/ConnectButton.tsx
@@ -17,6 +17,7 @@ import {
   useWalletService,
   useWallets,
 } from "../hooks";
+import { useHasActiveInteraction } from "../hooks/interaction";
 import type { WalletServiceId } from "../models";
 import { WALLET_SERVICES, walletServiceInfo } from "../models";
 import { deduplicate, isNotNull, shortenAddress } from "../utils";
@@ -45,6 +46,7 @@ export const ConnectButton = ({
   const selectedServiceByProtocol = useWalletAdapter(
     selectSelectedServiceByProtocol,
   );
+  const hasActiveInteraction = useHasActiveInteraction();
   const ecosystem = ecosystems[ecosystemId];
   const protocol = ecosystem.protocol;
   const wallets = useWallets();
@@ -65,6 +67,7 @@ export const ConnectButton = ({
         connected={connected}
         onClick={handleClick}
         iconType={ecosystem.logo}
+        isDisabled={hasActiveInteraction}
       >
         {connected && address ? (
           shortenAddress(address)
@@ -100,6 +103,7 @@ export const MultiConnectButton = ({
   );
   const evm = useEvmWallet();
   const solana = useSolanaWallet();
+  const hasActiveInteraction = useHasActiveInteraction();
 
   const connectedWalletServiceIds: ReadonlyArray<WalletServiceId> = deduplicate<
     WalletServiceId,
@@ -143,6 +147,7 @@ export const MultiConnectButton = ({
       <EuiButton
         onClick={openModal}
         {...rest}
+        isDisabled={hasActiveInteraction}
         className={`multiConnectButton ${rest.className ?? ""}`}
       >
         {label}

--- a/apps/ui/src/components/PlainConnectButton.tsx
+++ b/apps/ui/src/components/PlainConnectButton.tsx
@@ -10,7 +10,13 @@ import "./PlainConnectButton.scss";
 
 export type PlainConnectButtonProps = Pick<
   PropsForButton<EuiButtonProps>,
-  "onClick" | "iconType" | "children" | "className" | "fullWidth" | "size"
+  | "onClick"
+  | "iconType"
+  | "children"
+  | "className"
+  | "fullWidth"
+  | "size"
+  | "isDisabled"
 > & {
   readonly color?: "success" | "primary";
   readonly connected: boolean;


### PR DESCRIPTION
## Description

Disable disconnect button when interaction is progress

## PR Checklist

- [x] Tests for the changes have been added (optional but recommended)

<img width="985" alt="MetaMask_Notification_and_Swap___Swim_and_Slack___dev-frontend___Exsphere" src="https://user-images.githubusercontent.com/101085251/176130962-2906f0c2-6ee1-4c75-a01e-e4f63c4023f2.png">

- [x] The relevant Github Project (and/or label) has been assigned (applies only when there is one)

## Is there a ticket for this change? If yes, please paste the notion link below

https://www.notion.so/exsphere/33a3ed0734e24872ba8eaa0ddc83230a?v=e50f0fdd3ebf413595e48a9cf4c0d8aa&p=ca575abdbc0b4150adc66c1982080c6d