### PR TITLE
fix(ui): Circumvent ad blockers for Sentry

### DIFF
--- a/apps/ui/src/errors/sentry.ts
+++ b/apps/ui/src/errors/sentry.ts
@@ -23,7 +23,7 @@ export const setupSentry = (): void => {
 
     // Circumvent ad-blockers
     // Tunnel Sentry requests via Cloudflare Worker
-    tunnel: "https://swim.io/tunnel/",
+    tunnel: "https://tunnel.swim.io/",
 
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.


### PR DESCRIPTION
There are two parts: [`tunnel` option in our Sentry client](https://github.com/swim-io/swim/pull/149/files#diff-5aa33b2edf8fa305a8099def4a1150b3157b642945dab5f83a9dcb54d3ad9132R26) and the [tunnel request handler itself](https://github.com/swim-io/cf-sentry-tunnel/blob/main/src/index.ts).

### `tunnel` option
Sentry client POSTs requests to the specified endpoint which forwards requests to our Sentry DSN.

### Tunnel request handler
Request handler is a kind of web app that is deployed to Cloudflare Workers under [Swim account](https://dash.cloudflare.com/?to=/:account/workers/services/view/cf-sentry-tunnel/production). It [validates the request](https://github.com/swim-io/cf-sentry-tunnel/blob/68b738532254ef09c576d5a51d0573935933801d/src/index.ts#L12-L30), [sends request to Sentry](https://github.com/swim-io/cf-sentry-tunnel/blob/68b738532254ef09c576d5a51d0573935933801d/src/index.ts#L32-L51), and [returns the response from Sentry](https://github.com/swim-io/cf-sentry-tunnel/blob/68b738532254ef09c576d5a51d0573935933801d/src/index.ts#L53-L55).

It [handles](https://github.com/swim-io/cf-sentry-tunnel/blob/68b738532254ef09c576d5a51d0573935933801d/src/index.ts#L58-L68) and [reports errors](https://github.com/swim-io/cf-sentry-tunnel/blob/68b738532254ef09c576d5a51d0573935933801d/src/index.ts#L91) to the same Sentry project with [`logger = EdgeWorker` and `app = sentry-tunnel` tags to filter issues](https://sentry.io/organizations/swim/issues/?query=logger%3AEdgeWorker). [Toucan-js](https://github.com/robertcepa/toucan-js) is used instead of `@sentry/node` because Sentry client doesn't work _out-of-the-box_ in Workers environment.

### Problems
User Feedback Widget is still blocked. `tunnel` option doesn't change how `Sentry.showReportDialog` works. [More detailed issue](https://www.notion.so/exsphere/Circumvent-ad-blocking-for-Sentry-Crash-Report-dialog-e238c55e9e2a4d71a146e3dbe444fca5).


Notion link: https://www.notion.so/exsphere/Circumvent-ad-blockers-for-Sentry-49da2f19c87644ddb886f5cb6dab378c

### Checklist
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Create a private repo with CF Worker under `swim-io` organization. [Link to a repo][3].
- [x] Deploy worker [Swim account](https://dash.cloudflare.com/?to=/:account/workers/services/view/cf-sentry-tunnel/production)
- [x] Configure Cloudflare to proxy requests from `tunnel.swim.io` to a published CF Worker in [Workers -> Triggers -> Routes][2].
- [x] Github project and label have been assigned
- [x] Docs are added: https://github.com/swim-io/cf-sentry-tunnel/blob/main/README.md
- [x] Handle exceptions in [the worker itself](https://github.com/swim-io/cf-sentry-tunnel/blob/d9e79a832eae7660eb08757eeba5535e6b616904/src/index.ts#L53). [Example](https://github.com/bustle/cf-sentry/blob/df072afda307c64691701ebae2116ecfd60ad648/index.js#L12).
- [ ] ~~Circumvent ad blockers for [User Feedback Widget](https://docs.sentry.io/platforms/javascript/guides/react/components/errorboundary/). Too much work. Here's the [Notion link](https://www.notion.so/exsphere/Circumvent-ad-blocking-for-Sentry-Crash-Report-dialog-e238c55e9e2a4d71a146e3dbe444fca5) if we decide to fix it.~~

[1]: https://github.com/getsentry/examples/blob/c098c2bd97fbb15351a5206df41c4aff959b3b0a/tunneling/nextjs/pages/api/tunnel.js#L11-L38
[2]: https://dash.cloudflare.com/?to=/:account/workers/services/view/cf-sentry-tunnel/production/triggers
[3]: https://github.com/swim-io/cf-sentry-tunnel/blob/d9e79a832eae7660eb08757eeba5535e6b616904/src/index.ts#L42-L47

