### PR TITLE
fix(ui): Don't split `icon.search-js` to a separate chunk

### DIFF
--- a/apps/ui/src/euiIcons.tsx
+++ b/apps/ui/src/euiIcons.tsx
@@ -47,6 +47,8 @@ import { icon as EuiIconRefresh } from "@elastic/eui/es/components/icon/assets/r
 // @ts-expect-error no definitions
 import { icon as EuiIconReturnKey } from "@elastic/eui/es/components/icon/assets/return_key";
 // @ts-expect-error no definitions
+import { icon as EuiIconSearch } from "@elastic/eui/es/components/icon/assets/search";
+// @ts-expect-error no definitions
 import { icon as EuiIconVector } from "@elastic/eui/es/components/icon/assets/vector";
 // @ts-expect-error no definitions
 import { icon as EuiIconVisGauge } from "@elastic/eui/es/components/icon/assets/vis_gauge";
@@ -79,6 +81,7 @@ export const _ = appendIconComponentCache({
   questionInCircle: EuiIconQuestionInCircle,
   refresh: EuiIconRefresh,
   returnKey: EuiIconReturnKey,
+  search: EuiIconSearch,
   vector: EuiIconVector,
   visGauge: EuiIconVisGauge,
 });


### PR DESCRIPTION
Fixes recent ChunkLoadError issue in Sentry: https://sentry.io/organizations/swim/issues/3090594908/events/ad50b9084927407790eaa7e8e5cfb1ed/?environment=production&project=5931913&query=is%3Aunresolved

<!-- Add a short description of your changes unless they are obvious or trivial  -->

Notion ticket: https://www.notion.so/exsphere/ChunkLoad-errors-b897e58b9dc04df0b98b4a40769b8548

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
