### PR TITLE
[UI] new swap interaction state

### DIFF
--- a/apps/ui/src/models/swim/interaction.ts
+++ b/apps/ui/src/models/swim/interaction.ts
@@ -1,4 +1,5 @@
 import type { Keypair } from "@solana/web3.js";
+import type Decimal from "decimal.js";
 
 import type { EcosystemId, Env } from "../../config";
 import type { ReadonlyRecord } from "../../utils";
@@ -30,7 +31,7 @@ export const INTERACTION_GROUPS = [
   INTERACTION_GROUP_REMOVE,
 ];
 
-export interface BaseInteractionSpec {
+interface BaseInteractionSpec {
   readonly type: InteractionType;
   /** Should be overriden when extending this type */
   readonly params: unknown;
@@ -91,7 +92,7 @@ export type InteractionSpec =
   | RemoveExactBurnInteractionSpec
   | RemoveExactOutputInteractionSpec;
 
-export interface BaseInteraction {
+interface BaseInteraction {
   readonly id: string;
   // TODO: Make less redundant with poolId on non-Swap InteractionSpecs
   readonly poolIds: readonly string[];
@@ -129,3 +130,36 @@ export type Interaction =
   | RemoveExactBurnInteraction
   | RemoveExactOutputInteraction
   | SwapInteraction;
+
+// V2 for Pool Restructure
+interface TokenTransferDetail {
+  readonly tokenId: string;
+  readonly ecosystemId: EcosystemId;
+  readonly value: Decimal;
+}
+
+export interface SwapInteractionSpecV2 extends BaseInteractionSpec {
+  readonly type: InteractionType.SwapV2;
+  readonly params: {
+    readonly fromTokenDetail: TokenTransferDetail;
+    readonly toTokenDetail: TokenTransferDetail;
+  };
+}
+
+export type InteractionSpecV2 =
+  | SwapInteractionSpecV2
+  | AddInteractionSpec
+  | RemoveUniformInteractionSpec
+  | RemoveExactBurnInteractionSpec
+  | RemoveExactOutputInteractionSpec;
+
+export interface SwapInteractionV2
+  extends BaseInteraction,
+    SwapInteractionSpecV2 {}
+
+export type InteractionV2 =
+  | AddInteraction
+  | RemoveUniformInteraction
+  | RemoveExactBurnInteraction
+  | RemoveExactOutputInteraction
+  | SwapInteractionV2;

--- a/apps/ui/src/models/swim/interactionStateV2.ts
+++ b/apps/ui/src/models/swim/interactionStateV2.ts
@@ -1,39 +1,16 @@
-import type Decimal from "decimal.js";
-
-import type { EcosystemId } from "../../config";
 import type { EvmTx, SolanaTx } from "../crossEcosystem";
 
 import type {
   AddInteraction,
-  BaseInteraction,
-  BaseInteractionSpec,
-  InteractionType,
   RemoveExactBurnInteraction,
   RemoveExactOutputInteraction,
   RemoveUniformInteraction,
+  SwapInteractionV2,
 } from "./interaction";
 import type {
   RequiredSplTokenAccounts,
   SolanaPoolOperationState,
 } from "./interactionState";
-
-interface TokenTransferDetail {
-  readonly tokenId: string;
-  readonly ecosystemId: EcosystemId;
-  readonly value: Decimal;
-}
-
-export interface SwapInteractionSpecV2 extends BaseInteractionSpec {
-  readonly type: InteractionType.SwapV2;
-  readonly params: {
-    readonly fromTokenDetail: TokenTransferDetail;
-    readonly toTokenDetail: TokenTransferDetail;
-  };
-}
-
-export interface SwapInteractionV2
-  extends BaseInteraction,
-    SwapInteractionSpecV2 {}
 
 export enum SwapType {
   SingleChainSolana = "SingleChainSolana",
@@ -97,13 +74,6 @@ export interface RemoveInteractionState {
   readonly approvalTxIds: readonly EvmTx["txId"][];
   readonly removeTxId: string | null;
 }
-
-export type InteractionV2 =
-  | AddInteraction
-  | RemoveUniformInteraction
-  | RemoveExactBurnInteraction
-  | RemoveExactOutputInteraction
-  | SwapInteractionV2;
 
 export type InteractionStateV2 =
   | SingleChainSolanaSwapInteractionState


### PR DESCRIPTION
Proposal for new Swap interaction and state interface.

New interaction type for Swap, having a new interface `TokenTransferDetail` to include ecosystemId, since we need to handle swaping `swimUSD on A chain` to `swimUSD on B chain`.
```typescript
interface TokenTransferDetail {
  readonly tokenId: string;
  readonly ecosystemId: EcosystemId;
  readonly value: Decimal;
}

export interface SwapInteractionSpecV2 extends BaseInteractionSpec {
  readonly type: InteractionType.SwapV2;
  readonly params: {
    readonly fromTokenDetail: TokenTransferDetail;
    readonly toTokenDetail: TokenTransferDetail;
  };
}
```

Next breakdown the Swap state to different sub type, so that we can know what kind of tx is needed  for different swap pair

```ts
export type InteractionStateV2 =
  | SolanaSwapInteractionState
  | EvmSwapInteractionState
  | EvmCrossChainSwapInteractionState
  | SolanaToEvmSwapInteractionState
  | EvmToSolanaSwapInteractionState
  | AddInteractionState
  | RemoveInteractionState;
```

### Checklist

- [x] Github project and label have been assigned
- [ ] Tests have been added or are unnecessary
- [ ] Docs have been updated or are unnecessary
- [ ] Preview deployment works (visit the Cloudflare preview URL)
- [ ] Manual testing in #product-testing completed or unnecessary
