### PR TITLE
fix(ui): Fix not found error for reload interaction state

### DIFF
--- a/apps/ui/src/hooks/interaction/useReloadInteractionStateMutation.ts
+++ b/apps/ui/src/hooks/interaction/useReloadInteractionStateMutation.ts
@@ -15,6 +15,7 @@ import {
   isPoolTx,
   isPostVaaSolanaTx,
   isRedeemOnSolanaTx,
+  isRequiredSplTokenAccountsCompleted,
   isUnlockEvmTx,
 } from "../../models";
 import { findOrThrow } from "../../utils";
@@ -46,10 +47,16 @@ export const useReloadInteractionStateMutation = () => {
 
     const {
       interaction,
+      requiredSplTokenAccounts,
       toSolanaTransfers,
       solanaPoolOperations,
       fromSolanaTransfers,
     } = interactionState;
+
+    if (!isRequiredSplTokenAccountsCompleted(requiredSplTokenAccounts)) {
+      // Token accounts not ready
+      return;
+    }
 
     const requiredEcosystems = getRequiredEcosystems(tokens, interaction);
 


### PR DESCRIPTION
Sentry:
https://sentry.io/organizations/swim/issues/3404548495/?end=2022-07-06T08%3A37%3A59&project=5931913&query=firstRelease%3A47fb4e0&sort=freq&start=2022-07-05T14%3A15%3A00

Throwing because spl token account not found when recovering interaction state.
Add a check before all recover step, make sure token accounts are ready.

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
