### PR TITLE
refactor(ui): remove account field from RequiredSplTokenAccounts

### DIFF
--- a/apps/ui/src/components/molecules/InteractionStateComponent.stories.tsx
+++ b/apps/ui/src/components/molecules/InteractionStateComponent.stories.tsx
@@ -46,8 +46,8 @@ Init.args = {
 const stateWithExistingSplTokenAccounts: InteractionState = {
   ...MOCK_INTERACTION_STATE,
   requiredSplTokenAccounts: {
-    mint1: { isExistingAccount: true, account: null, txId: null },
-    mint2: { isExistingAccount: true, account: null, txId: null },
+    mint1: { isExistingAccount: true, txId: null },
+    mint2: { isExistingAccount: true, txId: null },
   },
 };
 export const ExistingSplTokenAccounts = Template.bind({});
@@ -60,12 +60,10 @@ const stateWithCreatedSplTokenAccounts: InteractionState = {
   requiredSplTokenAccounts: {
     mint1: {
       isExistingAccount: false,
-      account: null,
       txId: "createSplTokenAccountTxId1",
     },
     mint2: {
       isExistingAccount: false,
-      account: null,
       txId: "createSplTokenAccountTxId2",
     },
   },

--- a/apps/ui/src/fixtures/swim/interactionState.ts
+++ b/apps/ui/src/fixtures/swim/interactionState.ts
@@ -42,12 +42,10 @@ export const MOCK_INTERACTION_STATE: InteractionState = {
   requiredSplTokenAccounts: {
     "9idXDPGb5jfwaf5fxjiMacgUcwpy3ZHfdgqSjAV5XLDr": {
       isExistingAccount: false,
-      account: null,
       txId: null,
     },
     Ep9cMbgyG46b6PVvJNypopc6i8TFzvUVmGiT4MA1PhSb: {
       isExistingAccount: false,
-      account: null,
       txId: null,
     },
   },
@@ -134,12 +132,10 @@ export const MOCK_PREPARED_INTERACTION_STATE: PersistedInteractionState = {
   requiredSplTokenAccounts: {
     "9idXDPGb5jfwaf5fxjiMacgUcwpy3ZHfdgqSjAV5XLDr": {
       isExistingAccount: false,
-      account: null,
       txId: null,
     },
     Ep9cMbgyG46b6PVvJNypopc6i8TFzvUVmGiT4MA1PhSb: {
       isExistingAccount: false,
-      account: null,
       txId: null,
     },
   },

--- a/apps/ui/src/hooks/interaction/useCreateInteractionState.ts
+++ b/apps/ui/src/hooks/interaction/useCreateInteractionState.ts
@@ -58,7 +58,6 @@ export const createRequiredSplTokenAccounts = (
       ...state,
       [mint]: {
         isExistingAccount: accountForMint !== null,
-        account: accountForMint,
         txId: null,
       },
     };

--- a/apps/ui/src/hooks/interaction/usePrepareSplTokenAccountMutation.test.ts
+++ b/apps/ui/src/hooks/interaction/usePrepareSplTokenAccountMutation.test.ts
@@ -81,16 +81,10 @@ describe("usePrepareSplTokenAccountMutation", () => {
     expect(updatedState.requiredSplTokenAccounts).toEqual({
       "9idXDPGb5jfwaf5fxjiMacgUcwpy3ZHfdgqSjAV5XLDr": {
         isExistingAccount: false,
-        account: {
-          mint: "9idXDPGb5jfwaf5fxjiMacgUcwpy3ZHfdgqSjAV5XLDr",
-        },
         txId: "TX_ID_FOR_9idXDPGb5jfwaf5fxjiMacgUcwpy3ZHfdgqSjAV5XLDr",
       },
       Ep9cMbgyG46b6PVvJNypopc6i8TFzvUVmGiT4MA1PhSb: {
         isExistingAccount: false,
-        account: {
-          mint: "Ep9cMbgyG46b6PVvJNypopc6i8TFzvUVmGiT4MA1PhSb",
-        },
         txId: "TX_ID_FOR_Ep9cMbgyG46b6PVvJNypopc6i8TFzvUVmGiT4MA1PhSb",
       },
     });

--- a/apps/ui/src/models/swim/interactionState.ts
+++ b/apps/ui/src/models/swim/interactionState.ts
@@ -1,4 +1,3 @@
-import type { AccountInfo as TokenAccount } from "@solana/spl-token";
 import type Decimal from "decimal.js";
 
 import type { TokenSpec } from "../../config";
@@ -19,7 +18,6 @@ export interface InteractionState {
 
 export interface TokenAccountState {
   readonly isExistingAccount: boolean;
-  readonly account: TokenAccount | null;
   readonly txId: SolanaTx["txId"] | null;
 }
 


### PR DESCRIPTION
This field is actually not being use.
Inside mutation, we usually pull SPL token accounts from `useSplTokenAccountsQuery`

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [ ] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
