### PR TITLE
fix(ui): Use utils.captureException instead of Sentry directly

### DIFF
--- a/apps/ui/src/hooks/evm/useRegisterErc20Token.ts
+++ b/apps/ui/src/hooks/evm/useRegisterErc20Token.ts
@@ -1,8 +1,7 @@
-import * as Sentry from "@sentry/react";
-
 import type { EvmEcosystemId, TokenSpec } from "../../config";
 import { ECOSYSTEMS } from "../../config";
 import { useNotification } from "../../core/store";
+import { captureException } from "../../errors";
 
 import { useEvmChainId } from "./useEvmChainId";
 import { useEvmWallet } from "./useEvmWallet";
@@ -32,7 +31,7 @@ export const useRegisterErc20Token = (
       await wallet.registerToken(tokenSpec, ecosystemId, evmChainId);
     } catch (error) {
       notify("Error", "Failed to add token", "error");
-      Sentry.captureException(error);
+      captureException(error);
     }
   };
 

--- a/apps/ui/src/models/wallets/adapters/evm/EvmWalletAdapter.ts
+++ b/apps/ui/src/models/wallets/adapters/evm/EvmWalletAdapter.ts
@@ -6,6 +6,7 @@ import EventEmitter from "eventemitter3";
 
 import type { EcosystemId, EvmChainId, TokenSpec } from "../../../../config";
 import { ALL_UNIQUE_CHAINS, ECOSYSTEMS, Protocol } from "../../../../config";
+import { captureException } from "../../../../errors";
 import { sleep } from "../../../../utils";
 
 type Web3Provider = ethers.providers.Web3Provider;
@@ -120,9 +121,7 @@ export class EvmWeb3WalletAdapter
       });
     } catch (error) {
       await this.disconnect();
-      // TODO: parse actual errors from this
-      // Sentry.captureException(error);
-      console.error(error);
+      captureException(error);
     }
     this.connecting = false;
   }

--- a/apps/ui/src/models/wallets/adapters/solana/SolanaWalletAdapter.ts
+++ b/apps/ui/src/models/wallets/adapters/solana/SolanaWalletAdapter.ts
@@ -5,7 +5,7 @@ import { PublicKey } from "@solana/web3.js";
 import EventEmitter from "eventemitter3";
 
 import { Protocol } from "../../../../config";
-import { SolanaWalletError } from "../../../../errors";
+import { SolanaWalletError, captureException } from "../../../../errors";
 
 // TODO: Migrate to @solana/wallet-adapter.
 export interface SolanaWalletAdapter extends EventEmitter {
@@ -116,8 +116,7 @@ export class SolanaWeb3WalletAdapter
         `Connection to ${this.serviceName} failed.`,
       );
 
-      Sentry.captureException(error);
-      console.error(error);
+      captureException(error);
 
       this.connecting = false;
     }


### PR DESCRIPTION
We store in Sentry lots of `User rejected the request` which are supposed to be ignored. Because `Sentry.captureException` is used directly.

Example issue that is not filtered out: https://sentry.io/organizations/swim/issues/3384512378/

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing unnecessary
