### PR TITLE
refactor(ui): mock SwapForm dependencies to avoid network calls

### DIFF
--- a/apps/ui/src/components/SwapForm.test.tsx
+++ b/apps/ui/src/components/SwapForm.test.tsx
@@ -7,18 +7,16 @@ import type { UseQueryResult } from "react-query";
 import { EcosystemId, Env } from "../config";
 import { useEnvironment as environmentStore } from "../core/store";
 import {
+  useErc20BalanceQuery,
   useGetSwapFormErrors,
+  useLiquidityQueries,
+  useSolanaConnection,
+  useSplTokenAccountsQuery,
+  useSplUserBalance,
+  useStartNewInteraction,
   useSwapFeesEstimationQuery,
   useUserNativeBalances,
 } from "../hooks";
-import { useErc20BalanceQuery } from "../hooks/evm";
-import { useStartNewInteraction } from "../hooks/interaction";
-import {
-  useLiquidityQueries,
-  useSplTokenAccountsQuery,
-  useSplUserBalance,
-} from "../hooks/solana";
-import { useSolanaConnection } from "../hooks/solana/useSolanaConnection";
 import { mockOf, renderWithAppContext } from "../testUtils";
 
 import { SwapForm } from "./SwapForm";


### PR DESCRIPTION
I'm guilty about this, I remember implementing similar mocking on the first take, then thinking about if all this is necessary when there is no connected wallets, removing the mocks and seeing it working **without any logs**. I have no idea how that worked then but it was probably something on my local machine cause every pipeline I checked had the logs.

It would be nice to fail the pipeline when logs are detected but I've already spent some time on this in the past (while on swim) with no success.

Notion ticket: https://www.notion.so/exsphere/Investigate-logging-after-ends-of-tests-c139b6b090504b1bae4acf0bf1b196c1

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
