### PR TITLE
fix(pool-math): Fix marginal prices for constant product pools

### DIFF
--- a/docs/poolmath/swim_invariant.py
+++ b/docs/poolmath/swim_invariant.py
@@ -32,14 +32,18 @@ class SwimPool:
 
   def marginal_prices(self):
     depth = self.depth()
+    if self.amp_factor == 0:
+      fixed = depth * depth / (self.token_count * self.lp_supply)
+      return [fixed / balance for balance in self.balances]
+
     reciprocal_decay = Decimal(1)
     for balance in self.balances:
       reciprocal_decay *= depth / (self.token_count * balance)
+    fixed1 = depth * reciprocal_decay
     denominator = (self.amp_factor - 1) + (self.token_count + 1) * reciprocal_decay
-    return [
-      (self.amp_factor + depth * reciprocal_decay / balance) / denominator
-      for balance in self.balances
-    ]
+    pricedInLp = depth / self.lp_supply
+    fixed2 = denominator / pricedInLp
+    return [(self.amp_factor + fixed1 / balance) / fixed2 for balance in self.balances]
 
   def swap_exact_input(self, input_amounts, output_index, min_output_amount=0):
     return self.__swap(True, input_amounts, output_index, min_output_amount)

--- a/packages/pool-math/src/poolMath.test.ts
+++ b/packages/pool-math/src/poolMath.test.ts
@@ -250,6 +250,31 @@ describe("PoolMath", () => {
     },
   );
 
+  test.each([
+    [[1, 4], 4, ["2", "0.5"]],
+    [[1, 4], 2, ["4", "1"]],
+    [[1, 2, 4], 6, ["2", "1", "0.5"]],
+    [[1, 2, 4], 3, ["4", "2", "1"]],
+  ])(
+    "marginal prices for constant product pool",
+    (balances, lpSupply, expectedPrices) => {
+      const ampFactor = new Decimal("0");
+      const irrelevant = new Decimal("0");
+      const lpFee = irrelevant;
+      const governanceFee = irrelevant;
+      const pool = new PoolMath(
+        balances.map((b) => new Decimal(b)),
+        ampFactor,
+        lpFee,
+        governanceFee,
+        new Decimal(lpSupply),
+      );
+      expect(pool.marginalPrices()).toEqual(
+        expectedPrices.map((p) => new Decimal(p)),
+      );
+    },
+  );
+
   test("analytic (partial derivative) marginal prices agree with difference quotient method", () => {
     //epsilon is used to calculate the difference quotient from both sides to approximate
     // the partial derivative (=marginal price)
@@ -265,6 +290,10 @@ describe("PoolMath", () => {
     const governanceFee = irrelevant;
     const ampFactor = new Decimal(20);
     const pool = new PoolMath(balances, ampFactor, lpFee, governanceFee);
+    //importantly, since marginalPrices are given in lp tokens, this test
+    // relies on the default initialization of lpSupply = depth!
+    // (otherwise, we'd have to adjust for lpSupply in our difference quotient
+    //  function too)
     const marginalPrices = pool.marginalPrices();
 
     const marginalPriceDifferenceQuotient = (i: number): Decimal => {


### PR DESCRIPTION
Forgot to implement marginal prices for constant product pools when originally implementing proper marginal prices for Jupiter price impact. Also changed prices to be now stated in LP tokens rather than depth, which is a more natural representation.

Notion ticket: N/A

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
