### PR TITLE
[DO NOT MERGE] chore(ui): Add persist with indexeddb for interaction v2

### DIFF
--- a/apps/ui/src/components/molecules/InteractionStateComponentV2/InteractionStateComponentV2.tsx
+++ b/apps/ui/src/components/molecules/InteractionStateComponentV2/InteractionStateComponentV2.tsx
@@ -44,7 +44,7 @@ export const InteractionStateComponentV2: React.FC<Props> = ({
       option: {
         readonly onSettled: () => void;
       },
-    ) => {},
+    ) => option.onSettled(),
     [],
   );
 

--- a/apps/ui/src/core/store/idb/helpers.test.ts
+++ b/apps/ui/src/core/store/idb/helpers.test.ts
@@ -2,10 +2,16 @@ import {
   MOCK_INTERACTION_STATE,
   MOCK_PREPARED_INTERACTION_STATE,
 } from "../../../fixtures/swim/interactionState";
+import {
+  MOCK_SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT,
+  SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT,
+} from "../../../fixtures/swim/interactionStateV2";
 
 import {
   deserializeInteractionState,
+  deserializeInteractionStateV2,
   prepareInteractionState,
+  prepareInteractionStateV2,
 } from "./helpers";
 
 describe("idb helpers", () => {
@@ -17,5 +23,21 @@ describe("idb helpers", () => {
   it("should deserialize prepared Swap interaction state", () => {
     const swap = deserializeInteractionState(MOCK_PREPARED_INTERACTION_STATE);
     expect(swap).toEqual(MOCK_INTERACTION_STATE);
+  });
+
+  it("should serialize Swap interaction state V2", () => {
+    const preparedSwap = prepareInteractionStateV2(
+      SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT,
+    );
+    expect(preparedSwap).toEqual(
+      MOCK_SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT,
+    );
+  });
+
+  it("should deserialize Swap interaction state V2", () => {
+    const swap = deserializeInteractionStateV2(
+      MOCK_SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT,
+    );
+    expect(swap).toEqual(SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT);
   });
 });

--- a/apps/ui/src/core/store/idb/index.ts
+++ b/apps/ui/src/core/store/idb/index.ts
@@ -2,14 +2,23 @@ import type { Table } from "dexie";
 import Dexie from "dexie";
 
 import type { Env } from "../../../config";
-import type { InteractionState, InteractionType } from "../../../models";
+import type {
+  InteractionState,
+  InteractionStateV2,
+  InteractionType,
+} from "../../../models";
 import { INTERACTION_GROUPS } from "../../../models";
 import { isNotNull } from "../../../utils";
 
-import type { PersistedInteractionState } from "./helpers";
+import type {
+  PersistedInteractionState,
+  PersistedInteractionStateV2,
+} from "./helpers";
 import {
   deserializeInteractionState,
+  deserializeInteractionStateV2,
   prepareInteractionState,
+  prepareInteractionStateV2,
 } from "./helpers";
 
 const MAX_STORED_INTERACTIONS = 10;
@@ -26,12 +35,18 @@ type IDBState = {
   readonly id: string;
 } & PersistedInteractionState;
 
+type IDBStateV2 = {
+  readonly id: string;
+} & PersistedInteractionStateV2;
+
 class SwimIDB extends Dexie {
   interactionStates!: Table<IDBState, string>;
+  interactionStatesV2!: Table<IDBStateV2, string>;
 
   constructor() {
     super("SwimIDB");
     this.version(1).stores({ interactionStates: "&id" });
+    this.version(2).stores({ interactionStatesV2: "&id" });
   }
 }
 
@@ -116,9 +131,74 @@ export const putInteractionStateToDb = (interactionState: InteractionState) => {
     });
 };
 
-// eslint-disable-next-line import/no-unused-modules
-export const resetDb = () => {
-  return idb.transaction("rw", idb.interactionStates, async () => {
-    await Promise.all(idb.tables.map((table) => table.clear()));
+export const getInteractionStatesFromDbV2 = async (env: Env) => {
+  const data = await idb.interactionStatesV2
+    .filter((idbState) => idbState.interaction.env === env)
+    .reverse()
+    .sortBy("interaction.submittedAt");
+  return data
+    .map((datum) => {
+      try {
+        return deserializeInteractionStateV2(datum);
+      } catch (error) {
+        console.warn(
+          "Error during de-serialization of interaction",
+          datum,
+          error,
+        );
+        return null;
+      }
+    })
+    .filter(isNotNull);
+};
+
+export const addInteractionStateToDbV2 = (
+  interactionState: InteractionStateV2,
+) => {
+  (async () => {
+    const serializedState = prepareInteractionStateV2(interactionState);
+    await idb.interactionStatesV2.add(
+      {
+        id: interactionState.interaction.id,
+        ...serializedState,
+      },
+      interactionState.interaction.id,
+    );
+    const interactionGroup = getInteractionTypeGroup(
+      interactionState.interaction.type,
+    );
+    const collection = await idb.interactionStates
+      .filter(
+        (idbState) =>
+          idbState.interaction.env === interactionState.interaction.env &&
+          interactionGroup.has(idbState.interaction.type),
+      )
+      .sortBy("interaction.submittedAt");
+    const size = collection.length;
+    if (size > MAX_STORED_INTERACTIONS) {
+      const diff = size - MAX_STORED_INTERACTIONS;
+      for (let index = 0; index < diff; index++) {
+        await idb.interactionStates.delete(collection[index].id);
+      }
+    }
+  })().catch((err) => {
+    console.warn("Fail to add interactionState into idb", err);
+  });
+};
+
+export const putInteractionStateToDbV2 = (
+  interactionState: InteractionStateV2,
+) => {
+  (async () => {
+    const serializedState = prepareInteractionStateV2(interactionState);
+    await idb.interactionStatesV2.put(
+      {
+        id: interactionState.interaction.id,
+        ...serializedState,
+      },
+      interactionState.interaction.id,
+    );
+  })().catch((err) => {
+    console.warn("Fail to put interactionState into idb", err);
   });
 };

--- a/apps/ui/src/core/store/useInteractionStateV2.ts
+++ b/apps/ui/src/core/store/useInteractionStateV2.ts
@@ -9,6 +9,12 @@ import type { InteractionStateV2, InteractionV2 } from "../../models";
 import type { ReadonlyRecord } from "../../utils";
 import { findOrThrow } from "../../utils";
 
+import {
+  addInteractionStateToDbV2,
+  getInteractionStatesFromDbV2,
+  putInteractionStateToDbV2,
+} from "./idb";
+
 export interface InteractionStoreV2 {
   readonly errorMap: ReadonlyRecord<InteractionV2["id"], Error | undefined>;
   readonly interactionStates: readonly InteractionStateV2[];
@@ -40,8 +46,13 @@ export const useInteractionStateV2 = create(
         get().interactionStates,
         ({ interaction }) => interaction.id === id,
       ),
-    loadInteractionStatesFromIDB: async () => {
-      // TODO: load interaction state from db
+    loadInteractionStatesFromIDB: async (env) => {
+      const data = await getInteractionStatesFromDbV2(env);
+      set(
+        produce<InteractionStoreV2>((draft) => {
+          draft.interactionStates = castDraft(data);
+        }),
+      );
     },
     addInteractionState: (interactionState) => {
       set(
@@ -50,7 +61,7 @@ export const useInteractionStateV2 = create(
           draft.recentInteractionId = interactionState.interaction.id;
         }),
       );
-      // TODO: add interaction state to db
+      addInteractionStateToDbV2(interactionState);
     },
     updateInteractionState: (interactionId, updateCallback) => {
       set(
@@ -73,7 +84,7 @@ export const useInteractionStateV2 = create(
       if (!updatedInteractionState) {
         throw new Error("Updated interaction state not found");
       }
-      // TODO: update interaction state in db
+      putInteractionStateToDbV2(updatedInteractionState);
     },
   }),
 );

--- a/apps/ui/src/fixtures/swim/interactionStateV2.ts
+++ b/apps/ui/src/fixtures/swim/interactionStateV2.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js";
 
 import { EcosystemId, Env } from "../../config";
+import type { PersistedInteractionStateV2 } from "../../core/store/idb/helpers";
 import { Amount, InteractionType, SwapType } from "../../models";
 import type {
   AddInteraction,
@@ -688,3 +689,49 @@ export const REMOVE_EXACT_OUTPUT_INTERACTION_STATE_ETHEREUM_COMPLETED_WITH_APPRO
       "0x658875e6a68f242339bdf3db0f3a2f52274f6384ccdcf4a834b11f73996b7cab",
     ],
   };
+
+export const MOCK_SINGLE_CHAIN_SOLANA_SWAP_INTERACTION_STATE_INIT = {
+  interaction: {
+    connectedWallets: {
+      acala: null,
+      aurora: null,
+      avalanche: null,
+      bnb: null,
+      ethereum: null,
+      fantom: null,
+      karura: null,
+      polygon: null,
+      solana: "6sbzC1eH4FTujJXWj51eQe25cYvr4xfXbJ1vAj7j2k5J",
+    },
+    env: Env.Devnet,
+    id: "2eed9eef597a2aa14314845afe87079f",
+    params: {
+      fromTokenDetail: {
+        ecosystemId: EcosystemId.Solana,
+        tokenId: "devnet-solana-usdc",
+        value: "100",
+      },
+      toTokenDetail: {
+        ecosystemId: EcosystemId.Solana,
+        tokenId: "devnet-solana-usdt",
+        value: "101",
+      },
+    },
+    poolIds: ["devnet-solana-usdc-usdt"],
+    submittedAt: 1653624596234,
+    type: 5,
+  },
+  interactionType: InteractionType.SwapV2,
+  swapType: SwapType.SingleChainSolana,
+  onChainSwapTxId: null,
+  requiredSplTokenAccounts: {
+    "9idXDPGb5jfwaf5fxjiMacgUcwpy3ZHfdgqSjAV5XLDr": {
+      isExistingAccount: false,
+      txId: null,
+    },
+    Ep9cMbgyG46b6PVvJNypopc6i8TFzvUVmGiT4MA1PhSb: {
+      isExistingAccount: false,
+      txId: null,
+    },
+  },
+} as PersistedInteractionStateV2;

--- a/apps/ui/src/models/swim/interaction.ts
+++ b/apps/ui/src/models/swim/interaction.ts
@@ -17,7 +17,10 @@ export enum InteractionType {
   SwapV2,
 }
 
-export const INTERACTION_GROUP_SWAP = new Set([InteractionType.Swap]);
+export const INTERACTION_GROUP_SWAP = new Set([
+  InteractionType.Swap,
+  InteractionType.SwapV2,
+]);
 export const INTERACTION_GROUP_ADD = new Set([InteractionType.Add]);
 export const INTERACTION_GROUP_REMOVE = new Set([
   InteractionType.RemoveUniform,


### PR DESCRIPTION
This PR created a new DB table for storing interaction state V2.

The only different of persisted state is interaction, which we need to serialize `Amount` or `Decimal`
```ts
export interface PersistedInteractionStateV2
  extends Omit<InteractionStateV2, "interaction"> {
  readonly interaction: PreparedInteractionV2;
}
```

Do not merge now since it will change the db scheme, which is not backward compatible

Manual Testing:
https://user-images.githubusercontent.com/101085251/181167130-a08cb8a4-8298-450f-9909-e98b975fd687.mov


### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
