### PR TITLE
Unify token and ecosystem icon sizes.

### DIFF
--- a/apps/ui/src/components/TokenIcon.tsx
+++ b/apps/ui/src/components/TokenIcon.tsx
@@ -25,7 +25,7 @@ export const TokenIcon = ({
   const ecosystem = ecosystemId ? ECOSYSTEMS[ecosystemId] : null;
   return (
     <span>
-      <EuiIcon type={icon} size="l" title={symbol} />
+      <EuiIcon type={icon} size="m" title={symbol} />
       &nbsp;<span>{showFullName ? displayName : symbol}</span>
       {ecosystem && (
         <span>


### PR DESCRIPTION
[using "m"](https://files.slack.com/files-pri/T01V90M8LCW-F03RNAHBGKG/screen_shot_2022-08-01_at_12.16.20_pm.png) vs [using "l"](https://files.slack.com/files-pri/T01V90M8LCW-F03S7HZ4U81/screen_shot_2022-08-01_at_12.16.32_pm.png)

Nit: may want to look in other places, but I like small better.

Notion ticket: https://www.notion.so/exsphere/Fix-logo-sizes-for-tokens-ecosystems-ef7383d749224de8a6a24ee9fcdba408

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary