### PR TITLE
refactor(ui): Remove WormholeChainId type

### DIFF
--- a/apps/ui/src/config/ecosystem.ts
+++ b/apps/ui/src/config/ecosystem.ts
@@ -1,3 +1,5 @@
+import type { ChainId as WormholeChainId } from "@certusone/wormhole-sdk";
+import { CHAINS as WORMHOLE_CHAIN_IDS } from "@certusone/wormhole-sdk";
 import type { ReadonlyRecord } from "@swim-io/utils";
 import { filterMap } from "@swim-io/utils";
 
@@ -10,8 +12,6 @@ import FANTOM_SVG from "../images/ecosystems/fantom.svg";
 import KARURA_SVG from "../images/ecosystems/karura.svg";
 import POLYGON_SVG from "../images/ecosystems/polygon.svg";
 import SOLANA_SVG from "../images/ecosystems/solana.svg";
-
-import { WormholeChainId } from "./wormhole";
 
 export const enum Protocol {
   Solana = "solana-protocol",
@@ -110,7 +110,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Solana,
     protocol: Protocol.Solana,
-    wormholeChainId: WormholeChainId.Solana,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.solana,
     displayName: "Solana",
     logo: SOLANA_SVG,
     nativeTokenSymbol: "SOL",
@@ -118,7 +118,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Ethereum,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Ethereum,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.ethereum,
     displayName: "Ethereum",
     logo: ETHEREUM_SVG,
     nativeTokenSymbol: "ETH",
@@ -126,7 +126,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Bnb,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Bnb,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.bsc,
     displayName: "BNB Chain",
     logo: BNB_SVG,
     nativeTokenSymbol: "BNB",
@@ -134,7 +134,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Avalanche,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Avalanche,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.avalanche,
     displayName: "Avalanche",
     logo: AVALANCHE_SVG,
     nativeTokenSymbol: "AVAX",
@@ -142,7 +142,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Polygon,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Polygon,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.polygon,
     displayName: "Polygon",
     logo: POLYGON_SVG,
     nativeTokenSymbol: "MATIC",
@@ -150,7 +150,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Aurora,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Aurora,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.aurora,
     displayName: "Aurora",
     logo: AURORA_SVG,
     nativeTokenSymbol: "ETH",
@@ -158,7 +158,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Fantom,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Fantom,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.fantom,
     displayName: "Fantom",
     logo: FANTOM_SVG,
     nativeTokenSymbol: "FTM",
@@ -166,7 +166,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Karura,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Karura,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.karura,
     displayName: "Karura",
     logo: KARURA_SVG,
     nativeTokenSymbol: "KAR",
@@ -174,7 +174,7 @@ export const ECOSYSTEM_LIST: readonly Ecosystem[] = [
   {
     id: EcosystemId.Acala,
     protocol: Protocol.Evm,
-    wormholeChainId: WormholeChainId.Acala,
+    wormholeChainId: WORMHOLE_CHAIN_IDS.acala,
     displayName: "Acala",
     logo: ACALA_SVG,
     nativeTokenSymbol: "ACA",

--- a/apps/ui/src/config/wormhole.ts
+++ b/apps/ui/src/config/wormhole.ts
@@ -1,25 +1,6 @@
 import { Env } from "@swim-io/core";
 import type { ReadonlyRecord } from "@swim-io/utils";
 
-/** Adapted from @certusone/wormhole-sdk ChainId
- * https://pkg.go.dev/github.com/certusone/wormhole/node/pkg/vaa#ChainID
- */
-export const enum WormholeChainId {
-  Solana = 1,
-  Ethereum = 2,
-  Terra = 3,
-  Bnb = 4,
-  Polygon = 5, // NOTE: in some parts of the code, the listed order is swapped with Avalanche but ID is the same
-  Avalanche = 6,
-  Oasis = 7,
-  Algorand = 8,
-  Aurora = 9,
-  Fantom = 10,
-  Karura = 11,
-  Acala = 12,
-  Klaytn = 13,
-}
-
 export interface WormholeConfig {
   readonly rpcUrls: readonly string[];
 }

--- a/apps/ui/src/hooks/interaction/useFromSolanaTransferMutation.ts
+++ b/apps/ui/src/hooks/interaction/useFromSolanaTransferMutation.ts
@@ -1,4 +1,7 @@
-import { getEmitterAddressSolana } from "@certusone/wormhole-sdk";
+import {
+  CHAINS as WORMHOLE_CHAIN_IDS,
+  getEmitterAddressSolana,
+} from "@certusone/wormhole-sdk";
 import type { AccountInfo as TokenAccount } from "@solana/spl-token";
 import type { Transaction } from "@solana/web3.js";
 import { findOrThrow, isEachNotNull } from "@swim-io/utils";
@@ -9,7 +12,6 @@ import {
   ECOSYSTEMS,
   EcosystemId,
   Protocol,
-  WormholeChainId,
   getSolanaTokenDetails,
   getTokenDetailsForEcosystem,
 } from "../../config";
@@ -235,7 +237,7 @@ export const useFromSolanaTransferMutation = () => {
       );
       const vaaBytesResponse = await getSignedVaaWithRetry(
         [...wormhole.rpcUrls],
-        WormholeChainId.Solana,
+        WORMHOLE_CHAIN_IDS.solana,
         emitterAddress,
         sequence,
         undefined,

--- a/apps/ui/src/models/wormhole/attestation.ts
+++ b/apps/ui/src/models/wormhole/attestation.ts
@@ -1,4 +1,5 @@
 import {
+  CHAINS as WORMHOLE_CHAIN_IDS,
   attestFromEth,
   attestFromSolana,
   createWrappedOnEth,
@@ -12,7 +13,7 @@ import {
 import type { ContractReceipt } from "ethers";
 
 import type { EvmSpec, WormholeChainSpec, WormholeConfig } from "../../config";
-import { ECOSYSTEMS, EcosystemId, WormholeChainId } from "../../config";
+import { ECOSYSTEMS, EcosystemId } from "../../config";
 import type { SolanaConnection } from "../solana";
 import { DEFAULT_MAX_RETRIES } from "../solana";
 import type { EvmWalletAdapter, SolanaWalletAdapter } from "../wallets";
@@ -98,7 +99,7 @@ export const setUpSplTokensOnEvm = async (
     attestations.map(({ emitterAddress, sequence }) =>
       getSignedVaaWithRetry(
         [...rpcUrls],
-        WormholeChainId.Solana,
+        WORMHOLE_CHAIN_IDS.solana,
         emitterAddress,
         sequence,
       ),

--- a/apps/ui/src/models/wormhole/evm.ts
+++ b/apps/ui/src/models/wormhole/evm.ts
@@ -1,9 +1,12 @@
-import { getAllowanceEth } from "@certusone/wormhole-sdk";
+import {
+  CHAINS as WORMHOLE_CHAIN_IDS,
+  getAllowanceEth,
+} from "@certusone/wormhole-sdk";
 import { PublicKey } from "@solana/web3.js";
 import type { ethers } from "ethers";
 
 import type { TokenSpec, WormholeChainSpec } from "../../config";
-import { WormholeChainId, getTokenDetailsForEcosystem } from "../../config";
+import { getTokenDetailsForEcosystem } from "../../config";
 import type { EvmTx } from "../crossEcosystem";
 
 import { approveEth, transferFromEth } from "./overrides";
@@ -114,7 +117,7 @@ export const lockEvmToken = async ({
     evmSigner,
     evmTokenDetails.address,
     transferAmountAtomicString,
-    WormholeChainId.Solana,
+    WORMHOLE_CHAIN_IDS.solana,
     new PublicKey(splTokenAccountAddress).toBytes(),
   );
 

--- a/apps/ui/src/models/wormhole/solana.ts
+++ b/apps/ui/src/models/wormhole/solana.ts
@@ -1,4 +1,6 @@
+import type { ChainId as WormholeChainId } from "@certusone/wormhole-sdk";
 import {
+  CHAINS as WORMHOLE_CHAIN_IDS,
   chunks,
   createPostVaaInstructionSolana,
   createVerifySignaturesInstructionsSolana,
@@ -15,11 +17,7 @@ import type {
 import { PublicKey } from "@solana/web3.js";
 
 import type { TokenSpec, WormholeChainSpec } from "../../config";
-import {
-  EcosystemId,
-  WormholeChainId,
-  getSolanaTokenDetails,
-} from "../../config";
+import { EcosystemId, getSolanaTokenDetails } from "../../config";
 import type { SolanaTx } from "../crossEcosystem";
 import type { SolanaConnection } from "../solana";
 import {
@@ -185,7 +183,7 @@ export async function* generateUnlockSplTokenTxIds(
     throw new Error("No Solana public key");
   }
   const retries =
-    wormholeChainId === WormholeChainId.Polygon
+    wormholeChainId === WORMHOLE_CHAIN_IDS.polygon
       ? POLYGON_WORMHOLE_RETRIES
       : DEFAULT_WORMHOLE_RETRIES;
   const { vaaBytes } = await getSignedVaaWithRetry(
@@ -238,7 +236,7 @@ export const unlockSplToken = async (
     throw new Error("No Solana public key");
   }
   const retries =
-    wormholeChainId === WormholeChainId.Polygon
+    wormholeChainId === WORMHOLE_CHAIN_IDS.polygon
       ? POLYGON_WORMHOLE_RETRIES
       : DEFAULT_WORMHOLE_RETRIES;
   const { vaaBytes } = await getSignedVaaWithRetry(

--- a/apps/ui/src/pages/TestPage.tsx
+++ b/apps/ui/src/pages/TestPage.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { approveEth, getForeignAssetEth } from "@certusone/wormhole-sdk";
+import {
+  CHAINS as WORMHOLE_CHAIN_IDS,
+  approveEth,
+  getForeignAssetEth,
+} from "@certusone/wormhole-sdk";
 import {
   EuiButton,
   EuiCheckbox,
@@ -25,12 +29,7 @@ import shallow from "zustand/shallow.js";
 
 import { ConnectButton } from "../components/ConnectButton";
 import type { EvmEcosystemId } from "../config";
-import {
-  EcosystemId,
-  Protocol,
-  WormholeChainId,
-  getSolanaTokenDetails,
-} from "../config";
+import { EcosystemId, Protocol, getSolanaTokenDetails } from "../config";
 import { selectConfig } from "../core/selectors";
 import { useEnvironment, useNotification } from "../core/store";
 import {
@@ -365,7 +364,7 @@ const TestPage = (): ReactElement => {
       const foreignAsset = await getForeignAssetEth(
         ethereumChain.wormhole.tokenBridge,
         evmConnections[EcosystemId.Ethereum].provider,
-        WormholeChainId.Solana,
+        WORMHOLE_CHAIN_IDS.solana,
         wormholeAsset,
       );
       console.info(`${token}: ${String(foreignAsset)}`);
@@ -382,7 +381,7 @@ const TestPage = (): ReactElement => {
       const foreignAsset = await getForeignAssetEth(
         bnbChain.wormhole.tokenBridge,
         evmConnections[EcosystemId.Bnb].provider,
-        WormholeChainId.Solana,
+        WORMHOLE_CHAIN_IDS.solana,
         wormholeAsset,
       );
       console.info(`${token}: ${String(foreignAsset)}`);


### PR DESCRIPTION
This is preparation for SDK work. Specific chain IDs should in future be imported from the respective packages (Solana/Evm etc). For the general type we can use `ChainId` as exported from the Wormhole SDK.

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
