### PR TITLE
revert(ui): revert using useMemo to cache solana/evm connections

### DIFF
--- a/apps/ui/src/hooks/solana/useSolanaConnection.ts
+++ b/apps/ui/src/hooks/solana/useSolanaConnection.ts
@@ -1,5 +1,6 @@
 import { Keypair } from "@solana/web3.js";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
+import { useQueryClient } from "react-query";
 import shallow from "zustand/shallow.js";
 
 import { Protocol } from "../../config";
@@ -8,14 +9,22 @@ import { useEnvironment } from "../../core/store";
 import { SolanaConnection } from "../../models";
 
 export const useSolanaConnection = (): SolanaConnection => {
+  const { env } = useEnvironment();
   const { chains } = useEnvironment(selectConfig, shallow);
   const [chain] = chains[Protocol.Solana];
   const { endpoint, wsEndpoint } = chain;
 
-  const connection = useMemo(
-    () => new SolanaConnection(endpoint, wsEndpoint),
-    [endpoint, wsEndpoint],
-  );
+  const queryClient = useQueryClient();
+  const queryKey = [env, "solanaConnection"];
+
+  const connection =
+    // used as context cache to avoid multiple instances
+    queryClient.getQueryData<SolanaConnection>(queryKey) ||
+    (function createSolanaConnection(): SolanaConnection {
+      const solanaConnection = new SolanaConnection(endpoint, wsEndpoint);
+      queryClient.setQueryData(queryKey, solanaConnection);
+      return solanaConnection;
+    })();
 
   // The websocket library solana/web3.js uses closes its websocket connection when the subscription list
   // is empty after opening its first time, preventing subsequent subscriptions from receiving responses.


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

Using `useMemo` initialised multiple ws connection when these hooks are called, reverting the commit and add documentation

Notion ticket: N/A
Slack thread: https://exsphere.slack.com/archives/C0207URRE2G/p1659475042073139

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [ ] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
