### PR TITLE
chore(ui): fee estimation query V2

### DIFF
--- a/apps/ui/src/components/SwapFormV2/SwapFormV2.tsx
+++ b/apps/ui/src/components/SwapFormV2/SwapFormV2.tsx
@@ -85,7 +85,7 @@ export const SwapFormV2 = ({ maxSlippageFraction }: Props): ReactElement => {
     [],
   );
 
-  const feesEstimation = useSwapFeesEstimationQueryV2(
+  const { data: feesEstimation = null } = useSwapFeesEstimationQueryV2(
     fromTokenOption,
     toTokenOption,
   );

--- a/apps/ui/src/hooks/swim/index.ts
+++ b/apps/ui/src/hooks/swim/index.ts
@@ -1,4 +1,5 @@
 export * from "./useAddFeesEstimationQuery";
+export * from "./useAddFeesEstimationQueryV2";
 export * from "./useEvmTxFeesEstimateQuery";
 export * from "./useEvmTxFeesEstimates";
 export * from "./useGetSwapFormErrors";
@@ -9,6 +10,7 @@ export * from "./usePools";
 export * from "./usePoolState";
 export * from "./useRedeemMutation";
 export * from "./useRemoveFeesEstimationQuery";
+export * from "./useRemoveFeesEstimationQueryV2";
 export * from "./useSwapFeesEstimationQuery";
 export * from "./useSwapFeesEstimationQueryV2";
 export * from "./useSwapOutputAmountEstimate";

--- a/apps/ui/src/hooks/swim/useAddFeesEstimationQueryV2.test.ts
+++ b/apps/ui/src/hooks/swim/useAddFeesEstimationQueryV2.test.ts
@@ -1,0 +1,105 @@
+import { Env } from "@swim-io/core";
+import { waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react-hooks";
+import Decimal from "decimal.js";
+import { useQueryClient } from "react-query";
+
+import { EcosystemId } from "../../config";
+import { useEnvironment } from "../../core/store";
+import {
+  BNB_BUSD,
+  BNB_USDT,
+  ETHEREUM_USDC,
+  ETHEREUM_USDT,
+  SOLANA_USDC,
+  SOLANA_USDT,
+} from "../../fixtures";
+import { Amount } from "../../models";
+import { renderHookWithAppContext } from "../../testUtils";
+
+import { useAddFeesEstimationQueryV2 } from "./useAddFeesEstimationQueryV2";
+
+describe("useAddFeesEstimationQueryV2", () => {
+  beforeEach(() => {
+    const { result: envStore } = renderHook(() => useEnvironment());
+    act(() => {
+      envStore.current.setCustomIp("127.0.0.1");
+      envStore.current.setEnv(Env.Devnet);
+    });
+    const { result: queryClient } = renderHookWithAppContext(() =>
+      useQueryClient(),
+    );
+    queryClient.current.setQueryData(
+      [Env.Devnet, "gasPrice", EcosystemId.Ethereum],
+      new Decimal(7e-8),
+    );
+    queryClient.current.setQueryData(
+      [Env.Devnet, "gasPrice", EcosystemId.Bnb],
+      new Decimal(5e-9),
+    );
+  });
+
+  it("should return valid estimation for adding to Solana pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useAddFeesEstimationQueryV2(
+        [
+          Amount.fromHuman(SOLANA_USDC, new Decimal(99)),
+          Amount.fromHuman(SOLANA_USDT, new Decimal(99)),
+        ],
+        EcosystemId.Solana,
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0.01));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return ETH estimation for adding to Ethereum pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useAddFeesEstimationQueryV2(
+        [
+          Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
+          Amount.fromHuman(ETHEREUM_USDT, new Decimal(0)),
+        ],
+        EcosystemId.Ethereum,
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.0133));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return more ETH estimation for adding more token to Ethereum pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useAddFeesEstimationQueryV2(
+        [
+          Amount.fromHuman(ETHEREUM_USDC, new Decimal(99)),
+          Amount.fromHuman(ETHEREUM_USDT, new Decimal(99)),
+        ],
+        EcosystemId.Ethereum,
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.0182));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return BNB estimation for adding to BNB pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useAddFeesEstimationQueryV2(
+        [
+          Amount.fromHuman(BNB_BUSD, new Decimal(99)),
+          Amount.fromHuman(BNB_USDT, new Decimal(99)),
+        ],
+        EcosystemId.Bnb,
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0.0013));
+  });
+});

--- a/apps/ui/src/hooks/swim/useAddFeesEstimationQueryV2.ts
+++ b/apps/ui/src/hooks/swim/useAddFeesEstimationQueryV2.ts
@@ -1,0 +1,50 @@
+import { useQuery, useQueryClient } from "react-query";
+
+import { EcosystemId } from "../../config";
+import { useEnvironment } from "../../core/store";
+import type { Amount, FeesEstimation } from "../../models";
+import {
+  APPROVAL_CEILING,
+  SOLANA_FEE,
+  TRANSFER_CEILING,
+  ZERO_FEE,
+  getGasPrice,
+} from "../../models";
+import { useEvmConnections } from "../evm";
+
+export const useAddFeesEstimationQueryV2 = (
+  amounts: readonly (Amount | null)[],
+  poolEcosystem: EcosystemId,
+) => {
+  const { env } = useEnvironment();
+  const queryClient = useQueryClient();
+  const evmConnections = useEvmConnections();
+
+  const nonZeroTokenCount = amounts.filter(
+    (amount) => amount !== null && !amount.isZero(),
+  ).length;
+
+  return useQuery<FeesEstimation, Error>(
+    [env, "useAddFeesEstimationQueryV2", poolEcosystem, nonZeroTokenCount],
+    async () => {
+      if (poolEcosystem === EcosystemId.Solana) {
+        return {
+          ...ZERO_FEE,
+          [poolEcosystem]: SOLANA_FEE,
+        };
+      }
+      const gasPrice = await getGasPrice(
+        env,
+        queryClient,
+        poolEcosystem,
+        evmConnections,
+      );
+      return {
+        ...ZERO_FEE,
+        [poolEcosystem]: gasPrice.mul(
+          nonZeroTokenCount * APPROVAL_CEILING + TRANSFER_CEILING,
+        ),
+      };
+    },
+  );
+};

--- a/apps/ui/src/hooks/swim/useRemoveFeesEstimationQueryV2.test.ts
+++ b/apps/ui/src/hooks/swim/useRemoveFeesEstimationQueryV2.test.ts
@@ -1,0 +1,62 @@
+import { Env } from "@swim-io/core";
+import { waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react-hooks";
+import Decimal from "decimal.js";
+import { useQueryClient } from "react-query";
+
+import { EcosystemId } from "../../config";
+import { useEnvironment } from "../../core/store";
+import { renderHookWithAppContext } from "../../testUtils";
+
+import { useRemoveFeesEstimationQueryV2 } from "./useRemoveFeesEstimationQueryV2";
+
+describe("useRemoveFeesEstimationQueryV2", () => {
+  beforeEach(() => {
+    const { result: envStore } = renderHook(() => useEnvironment());
+    act(() => {
+      envStore.current.setCustomIp("127.0.0.1");
+      envStore.current.setEnv(Env.Devnet);
+    });
+    const { result: queryClient } = renderHookWithAppContext(() =>
+      useQueryClient(),
+    );
+    queryClient.current.setQueryData(
+      [Env.Devnet, "gasPrice", EcosystemId.Ethereum],
+      new Decimal(7e-8),
+    );
+    queryClient.current.setQueryData(
+      [Env.Devnet, "gasPrice", EcosystemId.Bnb],
+      new Decimal(5e-9),
+    );
+  });
+
+  it("should return valid estimation for removing from Solana pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useRemoveFeesEstimationQueryV2(EcosystemId.Solana),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0.01));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return ETH estimation for removing from Ethereum pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useRemoveFeesEstimationQueryV2(EcosystemId.Ethereum),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.0259));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return BNB estimation for removing from BNB pool", async () => {
+    const { result } = renderHookWithAppContext(() =>
+      useRemoveFeesEstimationQueryV2(EcosystemId.Bnb),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0.00185));
+  });
+});

--- a/apps/ui/src/hooks/swim/useRemoveFeesEstimationQueryV2.ts
+++ b/apps/ui/src/hooks/swim/useRemoveFeesEstimationQueryV2.ts
@@ -1,0 +1,41 @@
+import { useQuery, useQueryClient } from "react-query";
+
+import { EcosystemId } from "../../config";
+import { useEnvironment } from "../../core/store";
+import type { FeesEstimation } from "../../models";
+import {
+  APPROVAL_CEILING,
+  REDEEM_CEILING,
+  SOLANA_FEE,
+  ZERO_FEE,
+  getGasPrice,
+} from "../../models";
+import { useEvmConnections } from "../evm";
+
+export const useRemoveFeesEstimationQueryV2 = (poolEcosystem: EcosystemId) => {
+  const { env } = useEnvironment();
+  const queryClient = useQueryClient();
+  const evmConnections = useEvmConnections();
+
+  return useQuery<FeesEstimation, Error>(
+    [env, "useRemoveFeesEstimationQueryV2", poolEcosystem],
+    async () => {
+      if (poolEcosystem === EcosystemId.Solana) {
+        return {
+          ...ZERO_FEE,
+          [poolEcosystem]: SOLANA_FEE,
+        };
+      }
+      const gasPrice = await getGasPrice(
+        env,
+        queryClient,
+        poolEcosystem,
+        evmConnections,
+      );
+      return {
+        ...ZERO_FEE,
+        [poolEcosystem]: gasPrice.mul(APPROVAL_CEILING + REDEEM_CEILING),
+      };
+    },
+  );
+};

--- a/apps/ui/src/hooks/swim/useSwapFeesEstimationQueryV2.test.ts
+++ b/apps/ui/src/hooks/swim/useSwapFeesEstimationQueryV2.test.ts
@@ -1,0 +1,149 @@
+import { Env } from "@swim-io/core";
+import { act, renderHook } from "@testing-library/react-hooks";
+import Decimal from "decimal.js";
+import { useQueryClient } from "react-query";
+
+import { EcosystemId } from "../../config";
+import { useEnvironment } from "../../core/store";
+import { renderHookWithAppContext } from "../../testUtils";
+
+import { useSwapFeesEstimationQueryV2 } from "./useSwapFeesEstimationQueryV2";
+
+jest.mock("./useGasPriceQuery", () => ({
+  useGasPriceQuery: jest.fn(),
+}));
+
+describe("useSwapFeesEstimationQueryV2", () => {
+  beforeEach(() => {
+    const { result: envStore } = renderHook(() => useEnvironment());
+    act(() => {
+      envStore.current.setCustomIp("127.0.0.1");
+      envStore.current.setEnv(Env.Devnet);
+    });
+    const { result: queryClient } = renderHookWithAppContext(() =>
+      useQueryClient(),
+    );
+    queryClient.current.setQueryData(
+      [Env.Devnet, "gasPrice", EcosystemId.Ethereum],
+      new Decimal(7e-8),
+    );
+    queryClient.current.setQueryData(
+      [Env.Devnet, "gasPrice", EcosystemId.Bnb],
+      new Decimal(5e-9),
+    );
+  });
+
+  it("should return fixed fee for Solana => Solana", async () => {
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSwapFeesEstimationQueryV2(
+        {
+          tokenId: "devnet-solana-usdt",
+          ecosystemId: EcosystemId.Solana,
+        },
+        {
+          tokenId: "devnet-solana-usdc",
+          ecosystemId: EcosystemId.Solana,
+        },
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0.01));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return fee for Solana => Ethereum", async () => {
+    const { result, waitFor } = renderHookWithAppContext(() => {
+      return useSwapFeesEstimationQueryV2(
+        {
+          tokenId: "devnet-solana-usdt",
+          ecosystemId: EcosystemId.Solana,
+        },
+        {
+          tokenId: "devnet-ethereum-usdt",
+          ecosystemId: EcosystemId.Ethereum,
+        },
+      );
+    });
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0.01));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.021));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return fee for Solana => BNB", async () => {
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSwapFeesEstimationQueryV2(
+        {
+          tokenId: "devnet-solana-usdt",
+          ecosystemId: EcosystemId.Solana,
+        },
+        {
+          tokenId: "devnet-bnb-busd",
+          ecosystemId: EcosystemId.Bnb,
+        },
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0.01));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0.0015));
+  });
+
+  it("should return fee for Ethereum => Solana", async () => {
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSwapFeesEstimationQueryV2(
+        {
+          tokenId: "devnet-ethereum-usdt",
+          ecosystemId: EcosystemId.Ethereum,
+        },
+        {
+          tokenId: "devnet-solana-usdt",
+          ecosystemId: EcosystemId.Solana,
+        },
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0.01));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.0133));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0));
+  });
+
+  it("should return fee for Ethereum => BNB", async () => {
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSwapFeesEstimationQueryV2(
+        {
+          tokenId: "devnet-ethereum-usdt",
+          ecosystemId: EcosystemId.Ethereum,
+        },
+        {
+          tokenId: "devnet-bnb-busd",
+          ecosystemId: EcosystemId.Bnb,
+        },
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.0133));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0.0015));
+  });
+
+  it("should return fee for Ethereum => Ethereum", async () => {
+    const { result, waitFor } = renderHookWithAppContext(() =>
+      useSwapFeesEstimationQueryV2(
+        {
+          tokenId: "devnet-ethereum-usdt",
+          ecosystemId: EcosystemId.Ethereum,
+        },
+        {
+          tokenId: "devnet-ethereum-usdc",
+          ecosystemId: EcosystemId.Ethereum,
+        },
+      ),
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.solana).toEqual(new Decimal(0));
+    expect(result.current.data?.ethereum).toEqual(new Decimal(0.0343));
+    expect(result.current.data?.bnb).toEqual(new Decimal(0.0));
+  });
+});

--- a/apps/ui/src/models/swim/fees.ts
+++ b/apps/ui/src/models/swim/fees.ts
@@ -1,8 +1,13 @@
+import type { Env } from "@swim-io/core";
 import type { ReadonlyRecord } from "@swim-io/utils";
 import { getRecordKeys } from "@swim-io/utils";
 import Decimal from "decimal.js";
+import { utils as ethersUtils } from "ethers";
+import type { QueryClient } from "react-query";
 
+import type { EvmEcosystemId } from "../../config";
 import { EcosystemId } from "../../config";
+import type { EvmConnection } from "../evm";
 
 export type FeesEstimation = ReadonlyRecord<EcosystemId, Decimal>;
 
@@ -12,6 +17,19 @@ export const TRANSFER_CEILING = 120000;
 export const REDEEM_CEILING = 300000;
 export const SOLANA_FEE = new Decimal(0.01);
 const POLKADOT_EXISTENTIAL_DEPOSIT_AMOUNT = new Decimal(0.1);
+export const ZERO = new Decimal(0);
+
+export const ZERO_FEE = {
+  [EcosystemId.Solana]: ZERO,
+  [EcosystemId.Ethereum]: ZERO,
+  [EcosystemId.Bnb]: ZERO,
+  [EcosystemId.Avalanche]: ZERO,
+  [EcosystemId.Polygon]: ZERO,
+  [EcosystemId.Aurora]: ZERO,
+  [EcosystemId.Fantom]: ZERO,
+  [EcosystemId.Karura]: ZERO,
+  [EcosystemId.Acala]: ZERO,
+};
 
 export const getLowBalanceWallets = (
   feesEstimation: FeesEstimation | null,
@@ -35,4 +53,63 @@ export const getLowBalanceWallets = (
     }
     return userNativeBalances[ecosystemId].lessThan(fee);
   });
+};
+
+export const getGasPrice = async (
+  env: Env,
+  queryClient: QueryClient,
+  ecosystemId: EvmEcosystemId,
+  evmConnections: ReadonlyRecord<EvmEcosystemId, EvmConnection>,
+) => {
+  const cacheKey = [env, "gasPrice", ecosystemId];
+  const cache = queryClient.getQueryData<Decimal>(cacheKey);
+  if (cache) {
+    return cache;
+  }
+  const gasPriceInWei = await evmConnections[
+    ecosystemId
+  ].provider.getGasPrice();
+  const gasPriceInNativeCurrency = new Decimal(
+    ethersUtils.formatUnits(gasPriceInWei),
+  );
+  // Multiply by 1.1 to give some margin
+  const gasPrice = gasPriceInNativeCurrency.mul(1.1);
+  queryClient.setQueryData(cacheKey, gasPrice);
+  return gasPrice;
+};
+
+export const getTransferFee = async (
+  env: Env,
+  queryClient: QueryClient,
+  ecosystemId: EcosystemId,
+  evmConnections: ReadonlyRecord<EvmEcosystemId, EvmConnection>,
+) => {
+  if (ecosystemId === EcosystemId.Solana) {
+    return SOLANA_FEE;
+  }
+  const gasPrice = await getGasPrice(
+    env,
+    queryClient,
+    ecosystemId,
+    evmConnections,
+  );
+  return gasPrice.mul(APPROVAL_CEILING + TRANSFER_CEILING);
+};
+
+export const getRedeemFee = async (
+  env: Env,
+  queryClient: QueryClient,
+  ecosystemId: EcosystemId,
+  evmConnections: ReadonlyRecord<EvmEcosystemId, EvmConnection>,
+) => {
+  if (ecosystemId === EcosystemId.Solana) {
+    return SOLANA_FEE;
+  }
+  const gasPrice = await getGasPrice(
+    env,
+    queryClient,
+    ecosystemId,
+    evmConnections,
+  );
+  return gasPrice.mul(REDEEM_CEILING);
 };


### PR DESCRIPTION
Add fee estimation query V2
Since after pool restructure, it doesn't require to when through Solana, fees are different.
Created the hook with unit test.
No sure the math are correct.

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [ ] Docs have been updated or are unnecessary
- [ ] Preview deployment works (visit the Cloudflare preview URL)
- [ ] Manual testing in #product-testing completed or unnecessary
