### PR TITLE
fix(ui): Ignore ResizeObserver errors in Sentry

### DIFF
--- a/apps/ui/src/errors/sentry.ts
+++ b/apps/ui/src/errors/sentry.ts
@@ -38,6 +38,8 @@ export const setupSentry = (): void => {
       process.env.REACT_APP_ENV ?? "",
     ),
 
+    ignoreErrors: IGNORE_ERRORS,
+
     denyUrls: [
       // Chrome extensions
       /extensions\//i,
@@ -53,11 +55,6 @@ const beforeSend = (
   // extract error message
   const error = hint?.originalException ?? null;
   const errorMessage = error instanceof Error ? error.message : error;
-
-  // Ignore benign and known errors
-  if (IGNORE_ERRORS.includes(event.message ?? "")) {
-    return null;
-  }
 
   // eslint-disable-next-line functional/immutable-data
   event.fingerprint = fixFingerprint(event.fingerprint, errorMessage ?? "");


### PR DESCRIPTION
There are 3.2K errors as of time of this PR: https://sentry.io/organizations/swim/issues/2988474401/

Use [`ignoreErrors`][2] option from Sentry SDK to ignore ResizeObserver errors.

Here are the logs with the `debug: true` option. 

![image](https://user-images.githubusercontent.com/106807738/184631540-b6a0c9e3-913b-47f8-85a0-47013b70983b.png)

[2]: https://docs.sentry.io/clients/javascript/config

<!-- Add a short description of your changes unless they are obvious or trivial  -->

Notion ticket: N/A

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
