### PR TITLE
fix(ui): incorrect input amount after clicking user balance

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -64,6 +64,7 @@
     "classnames": "^2.3.1",
     "decimal.js": "^10.3.1",
     "dexie": "^3.2.2",
+    "escape-string-regexp": "^5.0.0",
     "ethers": "^5.6.9",
     "eventemitter3": "^4.0.7",
     "graphql": "^16.5.0",

--- a/apps/ui/src/components/AddForm.tsx
+++ b/apps/ui/src/components/AddForm.tsx
@@ -109,7 +109,7 @@ const TokenAddPanel = ({
       <EuiFieldIntlNumber
         placeholder={t("general.enter_amount_of_tokens")}
         name={tokenSpec.id}
-        defaultValue={inputAmount}
+        value={inputAmount}
         step={10 ** -tokenSpec.nativeDetails.decimals}
         fullWidth
         disabled={disabled}

--- a/apps/ui/src/components/molecules/TokenAmountInput.tsx
+++ b/apps/ui/src/components/molecules/TokenAmountInput.tsx
@@ -115,7 +115,7 @@ export const TokenAmountInput: React.FC<Props> = ({
           ) : (
             <EuiFieldIntlNumber
               placeholder={placeholder}
-              defaultValue={value}
+              value={value}
               step={10 ** -token.nativeDetails.decimals}
               min={0}
               onValueChange={onChangeValue}

--- a/apps/ui/src/components/molecules/TokenAmountInputV2.tsx
+++ b/apps/ui/src/components/molecules/TokenAmountInputV2.tsx
@@ -124,7 +124,7 @@ export const TokenAmountInputV2: React.FC<Props> = ({
           ) : (
             <EuiFieldIntlNumber
               placeholder={placeholder}
-              defaultValue={value}
+              value={value}
               step={10 ** -tokenDetails.decimals}
               min={0}
               onValueChange={onChangeValue}

--- a/apps/ui/src/hooks/browser/useI18n.test.ts
+++ b/apps/ui/src/hooks/browser/useI18n.test.ts
@@ -6,6 +6,7 @@ import {
   useIntlDateTimeFormatter,
   useIntlListSeparators,
   useIntlNumberFormatter,
+  useIntlNumberSeparators,
   useIntlRelativeTimeFromNow,
 } from "./useI18n";
 
@@ -151,6 +152,38 @@ describe("useI18n", () => {
 
       const { result } = renderHook(() => useIntlNumberFormatter());
       expect(result.current.format(1234)).toBe("1,234");
+    });
+  });
+
+  describe("useIntlNumberSeparators", () => {
+    const originalLanguage = i18next.resolvedLanguage;
+
+    afterEach(() => {
+      i18next.resolvedLanguage = originalLanguage;
+    });
+
+    it("should handle in english style", () => {
+      i18next.resolvedLanguage = "en";
+
+      const { result } = renderHook(() => useIntlNumberSeparators());
+      expect(result.current.decimal).toBe(".");
+      expect(result.current.group).toBe(",");
+    });
+
+    it("should handle in french style", () => {
+      i18next.resolvedLanguage = "fr";
+
+      const { result } = renderHook(() => useIntlNumberSeparators());
+      expect(result.current.decimal).toBe(",");
+      expect(result.current.group).toBe(" ");
+    });
+
+    it("should handle in english style if language is not supported", () => {
+      i18next.resolvedLanguage = "fake_not_supported";
+
+      const { result } = renderHook(() => useIntlNumberSeparators());
+      expect(result.current.decimal).toBe(".");
+      expect(result.current.group).toBe(",");
     });
   });
 

--- a/apps/ui/src/hooks/browser/useI18n.ts
+++ b/apps/ui/src/hooks/browser/useI18n.ts
@@ -84,6 +84,31 @@ export const useIntlListSeparators = (
   };
 };
 
+export const useIntlNumberSeparators = () => {
+  const numberFormatter = useIntlNumberFormatter();
+
+  return useMemo(() => {
+    const parts = numberFormatter.formatToParts(1234.5);
+
+    const decimalSeparator = parts.find(
+      (part) => part.type === "decimal",
+    )?.value;
+    if (!decimalSeparator) {
+      throw new Error("Could not find decimal separator");
+    }
+
+    const groupSeparator = parts.find((part) => part.type === "group")?.value;
+    if (!groupSeparator) {
+      throw new Error("Could not find group separator");
+    }
+
+    return {
+      decimal: decimalSeparator,
+      group: groupSeparator,
+    };
+  }, [numberFormatter]);
+};
+
 export const useIntlRelativeTimeFromNow = (
   options?: Intl.RelativeTimeFormatOptions,
 ) => {

--- a/apps/ui/src/models/amount.ts
+++ b/apps/ui/src/models/amount.ts
@@ -65,6 +65,7 @@ export class Amount {
     );
   }
 
+  /** Always parse from standard number which uses `,` as group separators and `.` as decimal separators */
   static fromHumanString(tokenSpec: TokenSpec, value: string): Amount {
     const strippedValue = value.replace(/,/g, "");
     return Amount.fromHuman(tokenSpec, new Decimal(strippedValue));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6701,6 +6701,7 @@ __metadata:
     classnames: ^2.3.1
     decimal.js: ^10.3.1
     dexie: ^3.2.2
+    escape-string-regexp: ^5.0.0
     eslint: ^8.18.0
     eslint-config-prettier: ^8.5.0
     eslint-config-react-app: ^7.0.1
@@ -13964,6 +13965,13 @@ __metadata:
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
   checksum: 98b48897d93060f2322108bf29db0feba7dd774be96cd069458d1453347b25ce8682ecc39859d4bca2203cc0ab19c237bcc71755eff49a0f8d90beadeeba5cc5
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

https://user-images.githubusercontent.com/109517311/185194720-4c6e132f-9e90-4c0f-b7f3-cba438858695.mov

Notion ticket: N/A
Slack: https://exsphere.slack.com/archives/C02PVCS2PKQ/p1660741889885469?thread_ts=1660734839.627329&cid=C02PVCS2PKQ

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
