### PR TITLE
fix(ui): cannot get i18n translation in notify prompt on load

### DIFF
--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -6,6 +6,9 @@ import { initReactI18next } from "react-i18next";
 
 import { Language } from "./config";
 
+// tmp hack to load translation before website is displayed
+import "./locales/en/translation.json";
+
 const fallbackLanguage = "en";
 
 // eslint-disable-next-line import/no-named-as-default-member


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

It is because a bug in either react-i18next or i18next-resources-to-backend, by default, following the way in react-i18next documentation, the website loads BEFORE translation downloaded.

Not sure proper fix yet, but one liner tmp fix is commited

Notion ticket: N/A
Slack: https://exsphere.slack.com/archives/C02PVCS2PKQ/p1660741538912869?thread_ts=1660734839.627329&cid=C02PVCS2PKQ

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
