### PR TITLE
Switch back to vanilla strings in notify

### DIFF
--- a/apps/ui/src/components/AddForm.tsx
+++ b/apps/ui/src/components/AddForm.tsx
@@ -439,8 +439,10 @@ export const AddForm = ({
       poolMath === null
     ) {
       notify(
-        t("notify.unexpected_form_error_title"),
-        t("notify.unexpected_form_error_description"),
+        // t("notify.unexpected_form_error_title"),
+        "Form error",
+        // t("notify.unexpected_form_error_description"),
+        "There was an unexpected error submitting the form. Developers were notified.",
         "error",
       );
       return;

--- a/apps/ui/src/components/NftCarousel/NftCarousel.tsx
+++ b/apps/ui/src/components/NftCarousel/NftCarousel.tsx
@@ -52,8 +52,10 @@ export const NftCarousel = ({ nfts }: Props): ReactElement => {
     try {
       await mutateAsync(activeNft);
       notify(
-        t("notify.redeem_success_title"),
-        t("notify.redeem_success_description", { redemptionAmount }),
+        // t("notify.redeem_success_title"),
+        "Success",
+        // t("notify.redeem_success_description", { redemptionAmount }),
+        `Redeemed Otter Tot for ${redemptionAmount}`,
         "success",
       );
       hideRedeemModal();

--- a/apps/ui/src/components/RemoveForm.tsx
+++ b/apps/ui/src/components/RemoveForm.tsx
@@ -424,8 +424,10 @@ export const RemoveForm = ({
     // pool errors
     if (!poolLpAmount) {
       notify(
-        t("notify.could_not_fetch_pool_lp_amount_error_title"),
-        t("notify.could_not_fetch_pool_lp_amount_error_description"),
+        // t("notify.could_not_fetch_pool_lp_amount_error_title"),
+        "Pool error",
+        // t("notify.could_not_fetch_pool_lp_amount_error_description"),
+        "Could not fetch pool LP amount",
         "error",
       );
       return;
@@ -544,8 +546,10 @@ export const RemoveForm = ({
       poolMath === null
     ) {
       notify(
-        t("notify.unexpected_form_error_title"),
-        t("notify.unexpected_form_error_description"),
+        // t("notify.unexpected_form_error_title"),
+        "Form error",
+        // t("notify.unexpected_form_error_description"),
+        "There was an unexpected error submitting the form. Developers were notified.",
         "error",
       );
       return;
@@ -652,8 +656,10 @@ export const RemoveForm = ({
               userHasAllLpTokens
             ) {
               notify(
-                t("notify.burn_all_lp_tokens_error_title"),
-                t("notify.burn_all_lp_tokens_error_description"),
+                // t("notify.burn_all_lp_tokens_error_title"),
+                "Invalid action",
+                // t("notify.burn_all_lp_tokens_error_description"),
+                "You are the only LP token holder. Please use the proportional remove method or select a lower burn percentage.",
                 "error",
               );
               return;

--- a/apps/ui/src/components/SwapForm/SwapForm.tsx
+++ b/apps/ui/src/components/SwapForm/SwapForm.tsx
@@ -215,8 +215,10 @@ export const SwapForm = ({ maxSlippageFraction }: Props): ReactElement => {
       !isEachNotNull(poolMaths)
     ) {
       notify(
-        t("notify.unexpected_form_error_title"),
-        t("notify.unexpected_form_error_description"),
+        // t("notify.unexpected_form_error_title"),
+        "Form error",
+        // t("notify.unexpected_form_error_description"),
+        "There was an unexpected error submitting the form. Developers were notified.",
         "error",
       );
       return;

--- a/apps/ui/src/components/SwapFormV2/SwapFormV2.tsx
+++ b/apps/ui/src/components/SwapFormV2/SwapFormV2.tsx
@@ -212,8 +212,10 @@ export const SwapFormV2 = ({ maxSlippageFraction }: Props): ReactElement => {
     // These are just for type safety and should in theory not happen
     if (outputAmount === null || maxSlippageFraction === null) {
       notify(
-        t("notify.unexpected_form_error_title"),
-        t("notify.unexpected_form_error_description"),
+        // t("notify.unexpected_form_error_title"),
+        "Form error",
+        // t("notify.unexpected_form_error_description"),
+        "There was an unexpected error submitting the form. Developers were notified.",
         "error",
       );
       return;

--- a/apps/ui/src/core/store/useWalletAdapter.ts
+++ b/apps/ui/src/core/store/useWalletAdapter.ts
@@ -109,10 +109,12 @@ export const useWalletAdapter = create(
         const handleConnect = (): void => {
           if (adapter.address) {
             notify(
-              i18next.t<string>("notify.connected_to_wallet_title"),
-              i18next.t<string>("notify.connected_to_wallet_description", {
-                walletAddress: truncate(adapter.address),
-              }),
+              // i18next.t<string>("notify.connected_to_wallet_title"),
+              "Wallet update",
+              // i18next.t<string>("notify.connected_to_wallet_description", {
+              //   walletAddress: truncate(adapter.address),
+              // }),
+              `Connected to wallet ${truncate(adapter.address)}}`,
               "info",
               7000,
             );
@@ -120,8 +122,10 @@ export const useWalletAdapter = create(
         };
         const handleDisconnect = (): void => {
           notify(
-            i18next.t<string>("notify.disconnected_from_wallet_title"),
-            i18next.t<string>("notify.disconnected_from_wallet_description"),
+            // i18next.t<string>("notify.disconnected_from_wallet_title"),
+            "Wallet update",
+            // i18next.t<string>("notify.disconnected_from_wallet_description"),
+            "Disconnected from wallet",
             "warning",
           );
           void disconnect();

--- a/apps/ui/src/hooks/evm/useRegisterErc20Token.ts
+++ b/apps/ui/src/hooks/evm/useRegisterErc20Token.ts
@@ -23,10 +23,12 @@ export const useRegisterErc20Token = (
   const showPrompt = async (tokenSpec: TokenSpec): Promise<void> => {
     if (!wallet) {
       notify(
-        t("notify.register_token_without_wallet_title"),
-        t("notify.register_token_without_wallet_description", {
-          ecosystemName: ECOSYSTEMS[ecosystemId].displayName,
-        }),
+        // t("notify.register_token_without_wallet_title"),
+        "No wallet",
+        // t("notify.register_token_without_wallet_description", {
+        //   ecosystemName: ECOSYSTEMS[ecosystemId].displayName,
+        // }),
+        `Connect ${ECOSYSTEMS[ecosystemId].displayName} wallet first`,
         "warning",
       );
       return;
@@ -36,8 +38,10 @@ export const useRegisterErc20Token = (
       await wallet.registerToken(tokenSpec, ecosystemId, evmChainId);
     } catch (error) {
       notify(
-        t("notify.register_token_failed_title"),
-        t("notify.register_token_failed_description"),
+        // t("notify.register_token_failed_title"),
+        "Error",
+        // t("notify.register_token_failed_description"),
+        "Failed to add token",
         "error",
       );
       captureException(error);


### PR DESCRIPTION
Temporary while we work out how to do these properly

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
