### PR TITLE
fix(ui): fix text break on token icon

### DIFF
--- a/apps/ui/src/components/TokenIcon.scss
+++ b/apps/ui/src/components/TokenIcon.scss
@@ -1,6 +1,8 @@
 .tokenIconItem {
-  white-space: pre-wrap;
-  max-width: 250px;
+  display: inline-flex;
+  align-items: center;
+  white-space: pre;
+  vertical-align: bottom;
 
   .euiIcon {
     vertical-align: text-bottom;

--- a/apps/ui/src/pages/PoolPage.scss
+++ b/apps/ui/src/pages/PoolPage.scss
@@ -1,0 +1,7 @@
+.statList {
+  .tokenIconItem {
+    display: inline;
+    white-space: pre-wrap;
+    max-width: 250px;
+  }
+}

--- a/apps/ui/src/pages/PoolPage.tsx
+++ b/apps/ui/src/pages/PoolPage.tsx
@@ -52,6 +52,8 @@ import BNB_SVG from "../images/ecosystems/bnb.svg";
 import ETHEREUM_SVG from "../images/ecosystems/ethereum.svg";
 import { isEvmPoolState } from "../models";
 
+import "./PoolPage.scss";
+
 const PoolPage = (): ReactElement => {
   const { t } = useTranslation();
   const { poolId } = useParams<{ readonly poolId: string }>();
@@ -278,7 +280,7 @@ export const PoolPageInner = ({
             ]}
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem grow={false} className="statList">
           <EuiTitle size="xxs">
             <h4>
               {t("pool_page.pool_balance", { count: reserveStats.length })}


### PR DESCRIPTION
Only break to newline in PoolPage stat list

<img width="899" alt="Cursor_and_Ethereum_USDC_USDT___Swim" src="https://user-images.githubusercontent.com/101085251/185545885-1d4e2108-c5b5-400e-bad5-eb1a96ea793a.png">


### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
