### PR TITLE
fix(ui): allow locales without group separator in useIntlNumberSeparators

### DIFF
--- a/apps/ui/src/hooks/browser/useI18n.test.ts
+++ b/apps/ui/src/hooks/browser/useI18n.test.ts
@@ -180,6 +180,17 @@ describe("useI18n", () => {
       expect(result.current.decimal).toBe(".");
       expect(result.current.group).toBe(",");
     });
+
+    it.each(["be", "bg", "ee", "es", "et", "ia", "ka", "lv", "pl", "sq"])(
+      "should handle locales which do not have group separators (%s)",
+      (language) => {
+        i18next.resolvedLanguage = language;
+
+        const { result } = renderHook(() => useIntlNumberSeparators());
+        expect(result.current.decimal).toBeTruthy();
+        expect(result.current.group).toBeNull();
+      },
+    );
   });
 
   describe("useIntlRelativeTimeFromNow", () => {

--- a/apps/ui/src/hooks/browser/useI18n.ts
+++ b/apps/ui/src/hooks/browser/useI18n.ts
@@ -84,7 +84,11 @@ export const useIntlListSeparators = (
   };
 };
 
-export const useIntlNumberSeparators = () => {
+export const useIntlNumberSeparators = (): {
+  readonly decimal: string;
+  /** some locales do not have group separator such as `es` */
+  readonly group: string | null;
+} => {
   const numberFormatter = useIntlNumberFormatter();
 
   return useMemo(() => {
@@ -97,10 +101,8 @@ export const useIntlNumberSeparators = () => {
       throw new Error("Could not find decimal separator");
     }
 
-    const groupSeparator = parts.find((part) => part.type === "group")?.value;
-    if (!groupSeparator) {
-      throw new Error("Could not find group separator");
-    }
+    const groupSeparator =
+      parts.find((part) => part.type === "group")?.value || null;
 
     return {
       decimal: decimalSeparator,


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

Follow up PR on https://github.com/swim-io/swim/pull/298#discussion_r948422331

Notion ticket: https://www.notion.so/exsphere/Improve-international-number-format-conversion-9e5062e3f52a427b971bbe8170877e7b

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
