### PR TITLE
fix: EuiFieldIntlNumber does not work with some number

### DIFF
--- a/apps/ui/src/components/EuiFieldIntlNumber.tsx
+++ b/apps/ui/src/components/EuiFieldIntlNumber.tsx
@@ -6,9 +6,8 @@ import escapeStringRegexp from "escape-string-regexp";
 import type { ComponentProps } from "react";
 import { forwardRef, useCallback } from "react";
 import CurrencyInput from "react-currency-input-field";
-import { useDeepCompareMemo } from "use-deep-compare";
 
-import { useI18nLanguage, useIntlNumberSeparators } from "../hooks";
+import { useIntlNumberSeparators } from "../hooks";
 
 /** Use `inputRef` as `ref` in order to get input element reference for `react-currency-input-field` to `setSelectionRange`. Without it, when adding/removing numbers with group separators (e.g. `,` for English), the cursor will always move to the end */
 const MappedEuiFieldNumber = forwardRef<
@@ -44,15 +43,8 @@ export const EuiFieldIntlNumber: React.FC<Props> = ({
   onValueChange: originalOnValueChange,
   ...props
 }) => {
-  const language = useI18nLanguage();
-  const intlConfig = useDeepCompareMemo(() => {
-    return {
-      ...props.intlConfig,
-      locale: language,
-    };
-  }, [language, props.intlConfig]);
-
-  const { decimal: decimalSeparator } = useIntlNumberSeparators();
+  const { decimal: decimalSeparator, group: groupSeparator } =
+    useIntlNumberSeparators();
 
   const onValueChange = useCallback<
     NonNullable<ComponentProps<typeof CurrencyInput>["onValueChange"]>
@@ -81,7 +73,10 @@ export const EuiFieldIntlNumber: React.FC<Props> = ({
       {...props}
       customInput={MappedEuiFieldNumber}
       decimalsLimit={props.decimalsLimit ?? 20} // default max value allowed by Intl.NumberFormat
-      intlConfig={intlConfig}
+      decimalSeparator={decimalSeparator}
+      groupSeparator={groupSeparator || undefined}
+      disableGroupSeparators={Boolean(groupSeparator)}
+      disableAbbreviations
       onValueChange={onValueChange}
       // always convert back to the current i18n format
       value={props.value.replace(/\./g, decimalSeparator)}

--- a/apps/ui/src/components/SwapForm/SwapForm.tsx
+++ b/apps/ui/src/components/SwapForm/SwapForm.tsx
@@ -259,7 +259,7 @@ export const SwapForm = ({ maxSlippageFraction }: Props): ReactElement => {
         disabled={isInteractionInProgress}
         errors={inputAmountErrors}
         onSelectToken={setFromToken}
-        onChangeValue={(value) => setFormInputAmount(value)}
+        onChangeValue={setFormInputAmount}
         onBlur={() => handleInputAmountChange(inputAmount)}
         showConstantSwapTip={!isStableSwap}
       />


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

It can be reproduced with specific number, e.g. `0.99972`

Big thanks to @wormat for spotting the [root cause](https://github.com/cchanxzy/react-currency-input-field/blob/7b740ca908c444437a6ba6e9d291f446a44a29ab/src/components/utils/formatValue.ts)!

Notion ticket: https://www.notion.so/exsphere/Swap-input-rounding-bug-551aaefbbb5a4cbba82bb7e27c7daf4c

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
