### PR TITLE
fix(ui): fix swimUsd not available

### DIFF
--- a/apps/ui/src/components/molecules/ClaimSwimUsdOnSolana.tsx
+++ b/apps/ui/src/components/molecules/ClaimSwimUsdOnSolana.tsx
@@ -19,6 +19,11 @@ export const ClaimSwimUsdOnSolana: VFC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const swimUsd = useSwimUsd();
+
+  if (swimUsd === null) {
+    return null;
+  }
+
   return (
     <EuiText size="m">
       <span style={{ display: "flex", alignItems: "center" }}>

--- a/apps/ui/src/components/molecules/SwapFromSwimUsd.tsx
+++ b/apps/ui/src/components/molecules/SwapFromSwimUsd.tsx
@@ -20,6 +20,9 @@ export const SwapFromSwimUsd: VFC<Props> = ({
   txId,
 }) => {
   const swimUsd = useSwimUsd();
+  if (swimUsd === null) {
+    return null;
+  }
   return (
     <SwapTransfer
       ecosystemId={ecosystemId}

--- a/apps/ui/src/components/molecules/SwapToSwimUsd.tsx
+++ b/apps/ui/src/components/molecules/SwapToSwimUsd.tsx
@@ -20,6 +20,9 @@ export const SwapToSwimUsd: VFC<Props> = ({
   txId,
 }) => {
   const swimUsd = useSwimUsd();
+  if (swimUsd === null) {
+    return null;
+  }
   return (
     <SwapTransfer
       ecosystemId={ecosystemId}

--- a/apps/ui/src/components/molecules/TransferSwimUsd.tsx
+++ b/apps/ui/src/components/molecules/TransferSwimUsd.tsx
@@ -14,6 +14,9 @@ interface Props {
 
 export const TransferSwimUsd: VFC<Props> = ({ from, to, isLoading, txId }) => {
   const swimUsd = useSwimUsd();
+  if (swimUsd === null) {
+    return null;
+  }
   return (
     <Transfer
       from={from}

--- a/apps/ui/src/hooks/interaction/useCreateInteractionStateV2.ts
+++ b/apps/ui/src/hooks/interaction/useCreateInteractionStateV2.ts
@@ -272,6 +272,9 @@ export const useCreateInteractionStateV2 = () => {
           addTxId: null,
         };
       case InteractionType.SwapV2:
+        if (swimUsd === null) {
+          throw new Error("Unsupported interaction type");
+        }
         return createSwapInteractionState(
           interaction,
           tokenAccounts,

--- a/apps/ui/src/hooks/swim/useSwapOutputAmountEstimateV2.ts
+++ b/apps/ui/src/hooks/swim/useSwapOutputAmountEstimateV2.ts
@@ -90,7 +90,7 @@ export const useSwapOutputAmountEstimateV2 = (
   const toToken = toTokenOption.tokenConfig;
   const swimUsdSpec = useSwimUsd();
 
-  if (!isEachNotNull(poolMaths)) {
+  if (!isEachNotNull(poolMaths) || swimUsdSpec === null) {
     return null;
   }
 

--- a/apps/ui/src/hooks/swim/useSwimUsd.ts
+++ b/apps/ui/src/hooks/swim/useSwimUsd.ts
@@ -1,4 +1,3 @@
-import { findOrThrow } from "@swim-io/utils";
 import { useMemo } from "react";
 import shallow from "zustand/shallow.js";
 
@@ -8,5 +7,5 @@ import { useEnvironment } from "../../core/store";
 
 export const useSwimUsd = () => {
   const { tokens } = useEnvironment(selectConfig, shallow);
-  return useMemo(() => findOrThrow(tokens, isSwimUsd), [tokens]);
+  return useMemo(() => tokens.find(isSwimUsd) ?? null, [tokens]);
 };


### PR DESCRIPTION
swimUsd is not available on Mainnet yet, hence this error happen
https://sentry.io/organizations/swim/issues/3582895712/?project=5931913&query=is%3Aunresolved

This PR replace findOrThrow with returning nullable in `useSwimUsd`