### PR TITLE
Put env at front of all query keys

### DIFF
--- a/apps/ui/src/hooks/evm/useErc20BalanceQuery.ts
+++ b/apps/ui/src/hooks/evm/useErc20BalanceQuery.ts
@@ -19,7 +19,7 @@ export const useErc20BalanceQuery = (
   const { address: walletAddress } = useEvmWallet();
 
   return useQuery<Decimal | null, Error>(
-    ["erc20Balance", env, ecosystemId, contractAddress, walletAddress],
+    [env, "erc20Balance", ecosystemId, contractAddress, walletAddress],
     async (): Promise<Decimal | null> => {
       if (walletAddress === null || contractAddress === null) {
         return null;

--- a/apps/ui/src/hooks/evm/useErc20BalancesQuery.ts
+++ b/apps/ui/src/hooks/evm/useErc20BalancesQuery.ts
@@ -20,8 +20,8 @@ export const useErc20BalancesQuery = (
   return useQueries(
     contractAddresses.map((contractAddress) => ({
       queryKey: [
-        "erc20Balance",
         env,
+        "erc20Balance",
         ecosystemId,
         contractAddress,
         walletAddress,

--- a/apps/ui/src/hooks/evm/useEvmUserNativeBalanceQuery.ts
+++ b/apps/ui/src/hooks/evm/useEvmUserNativeBalanceQuery.ts
@@ -18,7 +18,7 @@ export const useEvmUserNativeBalanceQuery = (
   const { address: walletAddress } = useEvmWallet();
 
   return useQuery<Decimal, Error>(
-    ["evmNativeBalance", env, ecosystemId, walletAddress],
+    [env, "evmNativeBalance", ecosystemId, walletAddress],
     async () => {
       if (!walletAddress) {
         return new Decimal(0);

--- a/apps/ui/src/hooks/interaction/useInteractionMutation.ts
+++ b/apps/ui/src/hooks/interaction/useInteractionMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 
-import { useInteractionState } from "../../core/store";
+import { useEnvironment, useInteractionState } from "../../core/store";
 
 import { useFromSolanaTransferMutation } from "./useFromSolanaTransferMutation";
 import { usePrepareSplTokenAccountMutation } from "./usePrepareSplTokenAccountMutation";
@@ -10,6 +10,7 @@ import { useToSolanaTransferMutation } from "./useToSolanaTransferMutation";
 export const INTERACTION_MUTATION_KEY = ["interactionMutation"];
 
 export const useInteractionMutation = () => {
+  const { env } = useEnvironment();
   const { setInteractionError } = useInteractionState();
 
   const { mutateAsync: prepareSplTokenAccountMutateAsync } =
@@ -39,8 +40,8 @@ export const useInteractionMutation = () => {
         setInteractionError(interactionId, error);
       },
       onSettled: async () => {
-        await queryClient.invalidateQueries(["erc20Balance"]);
-        await queryClient.invalidateQueries(["tokenAccounts"]);
+        await queryClient.invalidateQueries([env, "erc20Balance"]);
+        await queryClient.invalidateQueries([env, "tokenAccounts"]);
       },
     },
   );

--- a/apps/ui/src/hooks/interaction/useInteractionMutationV2.ts
+++ b/apps/ui/src/hooks/interaction/useInteractionMutationV2.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 
-import { useInteractionStateV2 } from "../../core/store";
+import { useEnvironment, useInteractionStateV2 } from "../../core/store";
 import { InteractionType, SwapType } from "../../models";
 
 import { useAddInteractionMutation } from "./useAddInteractionMutation";
@@ -14,6 +14,7 @@ import { useSingleChainSolanaSwapInteractionMutation } from "./useSingleChainSol
 export const INTERACTION_MUTATION_KEY_V2 = ["interactionMutationV2"];
 
 export const useInteractionMutationV2 = () => {
+  const { env } = useEnvironment();
   const { getInteractionState, setInteractionError } = useInteractionStateV2();
   const queryClient = useQueryClient();
 
@@ -81,8 +82,8 @@ export const useInteractionMutationV2 = () => {
         setInteractionError(interactionId, error);
       },
       onSettled: async () => {
-        await queryClient.invalidateQueries(["erc20Balance"]);
-        await queryClient.invalidateQueries(["tokenAccounts"]);
+        await queryClient.invalidateQueries([env, "erc20Balance"]);
+        await queryClient.invalidateQueries([env, "tokenAccounts"]);
       },
     },
   );

--- a/apps/ui/src/hooks/solana/useCreateSplTokenAccountsMutation.ts
+++ b/apps/ui/src/hooks/solana/useCreateSplTokenAccountsMutation.ts
@@ -37,7 +37,7 @@ const findOrCreateSplTokenAccount = async (
   const solanaAddress = wallet.publicKey.toBase58();
   await solanaConnection.createSplTokenAccount(wallet, splTokenMintAddress);
   await sleep(1000); // TODO: Find a better condition
-  await queryClient.invalidateQueries(["tokenAccounts", env, solanaAddress]);
+  await queryClient.invalidateQueries([env, "tokenAccounts", solanaAddress]);
   return solanaConnection.getTokenAccountWithRetry(
     splTokenMintAddress,
     solanaAddress,
@@ -77,7 +77,7 @@ export const useCreateSplTokenAccountsMutation = (): UseMutationResult<
           ),
         ),
       );
-      await queryClient.invalidateQueries(["tokenAccounts", env, address]);
+      await queryClient.invalidateQueries([env, "tokenAccounts", address]);
       return tokenAccounts;
     },
   );

--- a/apps/ui/src/hooks/solana/useSolBalanceQuery.ts
+++ b/apps/ui/src/hooks/solana/useSolBalanceQuery.ts
@@ -16,7 +16,7 @@ export const useSolBalanceQuery = (
   const solanaConnection = useSolanaConnection();
   const { address: walletAddress } = useSolanaWallet();
   return useQuery<Decimal, Error>(
-    ["solBalance", env, walletAddress],
+    [env, "solBalance", walletAddress],
     async () => {
       if (!walletAddress) {
         return new Decimal(0);

--- a/apps/ui/src/hooks/solana/useSolanaLiquidityQuery.ts
+++ b/apps/ui/src/hooks/solana/useSolanaLiquidityQuery.ts
@@ -13,7 +13,7 @@ export const useSolanaLiquidityQuery = (
   const solanaConnection = useSolanaConnection();
 
   return useQuery<readonly (TokenAccount | null)[], Error>(
-    ["liquidity", env, tokenAccountAddresses.join("")],
+    [env, "liquidity", tokenAccountAddresses.join("")],
     async () => {
       if (tokenAccountAddresses.length === 0) {
         return [];
@@ -34,7 +34,7 @@ export const useSolanaLiquidityQueries = (
 
   return useQueries(
     tokenAccountAddresses.map((addresses) => ({
-      queryKey: ["liquidity", env, addresses.join("")],
+      queryKey: [env, "liquidity", addresses.join("")],
       queryFn: async (): Promise<readonly (TokenAccount | null)[]> => {
         if (addresses.length === 0) {
           return [];

--- a/apps/ui/src/hooks/solana/useSplTokenAccountsQuery.ts
+++ b/apps/ui/src/hooks/solana/useSplTokenAccountsQuery.ts
@@ -14,7 +14,7 @@ import { useSolanaWallet } from "./useSolanaWallet";
 export const getSplTokenAccountsQueryKey = (
   env: Env,
   address: string | null,
-) => ["tokenAccounts", env, address];
+) => [env, "tokenAccounts", address];
 
 export const useSplTokenAccountsQuery = (
   owner?: string,
@@ -26,7 +26,7 @@ export const useSplTokenAccountsQuery = (
   const address = owner ?? userAddress;
 
   const queryKey = getSplTokenAccountsQueryKey(env, address);
-  const query = useQuery<readonly TokenAccount[], Error>(
+  return useQuery<readonly TokenAccount[], Error>(
     queryKey,
     async () => {
       if (address === null) {
@@ -42,6 +42,4 @@ export const useSplTokenAccountsQuery = (
     },
     options,
   );
-
-  return query;
 };

--- a/apps/ui/src/hooks/swim/useGasPriceQuery.ts
+++ b/apps/ui/src/hooks/swim/useGasPriceQuery.ts
@@ -16,7 +16,7 @@ export const useGasPriceQueries = (
 
   return useQueries(
     evmEcosystemIds.map((evmEcosystemId, i) => ({
-      queryKey: ["gasPrice", env, evmEcosystemId],
+      queryKey: [env, "gasPrice", evmEcosystemId],
       queryFn: async () => {
         const gasPriceInWei = await connections[i].provider.getGasPrice();
         const gasPriceInNativeCurrency = new Decimal(

--- a/apps/ui/src/hooks/swim/usePoolLpMint.ts
+++ b/apps/ui/src/hooks/swim/usePoolLpMint.ts
@@ -21,7 +21,7 @@ export const usePoolLpMints = (
 
   return useQueries(
     poolSpecs.map((poolSpec) => ({
-      queryKey: ["poolLpMintAccount", env, poolSpec.id],
+      queryKey: [env, "poolLpMintAccount", poolSpec.id],
       queryFn: async () => {
         if (poolSpec.ecosystem !== SOLANA_ECOSYSTEM_ID) {
           return null;

--- a/apps/ui/src/pages/TestPage.tsx
+++ b/apps/ui/src/pages/TestPage.tsx
@@ -249,7 +249,7 @@ const TestPage = (): ReactElement => {
       )) ?? null;
     setInitTxIds(newInitTxIds);
     await sleep(1000);
-    await queryClient.invalidateQueries(["poolState", env, poolSpec.address]);
+    await queryClient.invalidateQueries([env, "poolState", poolSpec.id]);
   };
 
   const attestLpToken = async (): Promise<void> => {


### PR DESCRIPTION
Fixes the ordering of query keys. 

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [ ] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
