### PR TITLE
refactor(ui): split ui-verify to verify and storybook jobs

### DIFF
--- a/.github/workflows/ui-verify.yaml
+++ b/.github/workflows/ui-verify.yaml
@@ -110,6 +110,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_SWIM_PAGES_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
+          set -o errexit -o nounset -o pipefail
           npx --yes wrangler@2 pages publish storybook-static --project-name=ui-storybook --branch=${{ github.head_ref || github.ref_name }} | tee wrangler-output.txt
           echo "::set-output name=storybook-deployment::$(grep Deployment wrangler-output.txt)"
       - name: Find storybook comment


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

Notion ticket: https://www.notion.so/exsphere/Move-storybook-deployment-to-a-separate-job-f36f9c3665c84c87a72db40ccc62a895

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
