### PR TITLE
Make default (or "unsupported") routes navigate to the home page

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -71,6 +71,7 @@ function App(): ReactElement {
               <Route path="help" element={<HelpPage />} />
               <Route path="security" element={<SecurityPage />} />
               <Route path="/" element={<HomePage />} />
+              <Route path="*" element={<Navigate to="/" />} />
             </Routes>
           </Layout>
         </AppContext>


### PR DESCRIPTION
Use react router's "No Match" route navigate to the home page. This route is triggered when the URL is not supported.

Notion ticket: Could replace this ticket to make a 404 page?

https://www.notion.so/exsphere/33a3ed0734e24872ba8eaa0ddc83230a?v=e50f0fdd3ebf413595e48a9cf4c0d8aa&p=07b1925a9fd1463fb8d73627c435a5d4&pm=s

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [ ] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
