### PR TITLE
Handle null results from Solana Connection.getMultipleAccountsInfo

### DIFF
--- a/apps/ui/src/hooks/swim/usePoolBalances.ts
+++ b/apps/ui/src/hooks/swim/usePoolBalances.ts
@@ -1,5 +1,5 @@
 import { SOLANA_ECOSYSTEM_ID } from "@swim-io/solana";
-import { findOrThrow } from "@swim-io/utils";
+import { findOrThrow, isEachNotNull } from "@swim-io/utils";
 import type { PoolSpec } from "config";
 import Decimal from "decimal.js";
 import shallow from "zustand/shallow.js";
@@ -32,16 +32,13 @@ export const usePoolBalances = (poolSpecs: readonly PoolSpec[]) => {
       const poolTokens = poolSpec.tokens.map((tokenId) =>
         findOrThrow(tokens, ({ id }) => id === tokenId),
       );
-      const { data: allPoolTokenAccounts = null } = liquidityQueries[index];
-      if (allPoolTokenAccounts === null) {
+      const { data: poolTokenAccounts = null } = liquidityQueries[index];
+      if (poolTokenAccounts === null || !isEachNotNull(poolTokenAccounts)) {
         return null;
       }
       return poolTokens.map((tokenConfig, i) => {
         const solanaDetails = getSolanaTokenDetails(tokenConfig);
-        const tokenAccount = allPoolTokenAccounts[i];
-        if (tokenAccount === null) {
-          throw new Error("Missing pool token account");
-        }
+        const tokenAccount = poolTokenAccounts[i];
         return new Decimal(tokenAccount.amount.toString()).div(
           Decimal.pow(10, solanaDetails.decimals),
         );

--- a/apps/ui/src/hooks/swim/usePools.ts
+++ b/apps/ui/src/hooks/swim/usePools.ts
@@ -134,10 +134,9 @@ export const usePools = (poolIds: readonly string[]): readonly PoolData[] => {
   );
 
   return poolSpecs.map((poolSpec, i) => {
-    const { data: poolTokenAccounts = null } = liquidityQueries[i];
-    if (poolTokenAccounts !== null && !isEachNotNull(poolTokenAccounts)) {
-      throw new Error("Missing token account");
-    }
+    const { data = null } = liquidityQueries[i];
+    const poolTokenAccounts =
+      data !== null && isEachNotNull(data) ? data : null;
     return constructPool(
       allTokens,
       poolSpec,


### PR DESCRIPTION
It seems like somehow this is returning `null` results sometimes for accounts which definitely exist.

EDIT: this was actually always the case, but we used to filter out the `null` accounts: https://github.com/swim-io/swim/commit/750df62e79420055cbe7e6e736ea703249ecf405#diff-ea16336f6b1ba34d576bc7cebd7f55c714a73d4608ae872cd9933166e9344597L304

This is probably a more robust approach than what we had before.

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
