### PR TITLE
ci(ui): build related monorepo dependencies when deploy

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "scripts": {
     "start": "NODE_ENV=development SKIP_PREFLIGHT_CHECK=true DISABLE_ESLINT_PLUGIN=true craco start",
-    "build": "craco build",
-    "release": "SENTRY_RELEASE=$(git rev-parse --short HEAD) SKIP_PREFLIGHT_CHECK=true DISABLE_ESLINT_PLUGIN=true craco build",
+    "build": "SKIP_PREFLIGHT_CHECK=true DISABLE_ESLINT_PLUGIN=true craco build",
+    "release": "SENTRY_RELEASE=$(git rev-parse --short HEAD) yarn workspaces foreach --topological-dev --parallel --recursive --from @swim-io/ui run build",
     "test": "craco test --env \"./jest-custom-jsdom-env.cjs\" --transformIgnorePatterns \"node_modules/(?!escape-string-regexp)/\"",
     "eject": "react-scripts eject",
     "format": "prettier --write .",


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

Working example with `workspace:^` in ui's package.json: https://dash.cloudflare.com/21fe306b23881c1b0affeb8164d46ba5/pages/view/swim-ui/b885e8c4-7684-4278-a00a-3ffa58565ba5

Issues:
1. We keep hitting `JavaScript heap out of memory` when building in cloudflare, seems it does not have enough ram as github workflow to build all dependencies. The workaround is to disable source map for preview env with env variable: `GENERATE_SOURCEMAP=false`
2. Does not build evm-contracts yet because it requires specific env, will handle it in next pr

Notion ticket: https://www.notion.so/exsphere/Test-SDKs-in-UI-without-publishing-3b0e9fd7273f4c8dbb341364217ea11c

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
