### PR TITLE
refactor: exit workflow script when any command fails

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash
+        shell: bash --noprofile --norc -o errexit -o nounset -o pipefail {0}
 
     # Allow only one concurrent deployment
     concurrency:

--- a/.github/workflows/evm-contracts-verify.yaml
+++ b/.github/workflows/evm-contracts-verify.yaml
@@ -17,7 +17,7 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/evm-contracts
-        shell: bash
+        shell: bash --noprofile --norc -o errexit -o nounset -o pipefail {0}
 
     env:
       MNEMONIC: "test test test test test test test test test test test junk"

--- a/.github/workflows/solana-contracts-verify.yaml
+++ b/.github/workflows/solana-contracts-verify.yaml
@@ -22,7 +22,7 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/solana-contracts
-        shell: bash
+        shell: bash --noprofile --norc -o errexit -o nounset -o pipefail {0}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ui-verify.yaml
+++ b/.github/workflows/ui-verify.yaml
@@ -24,7 +24,7 @@ jobs:
     defaults:
       run:
         working-directory: ./apps/ui
-        shell: bash
+        shell: bash --noprofile --norc -o errexit -o nounset -o pipefail {0}
 
     env:
       REACT_APP_BNB_MAINNET_RPC_URL: "https://example.com"
@@ -71,7 +71,7 @@ jobs:
     defaults:
       run:
         working-directory: ./apps/ui
-        shell: bash
+        shell: bash --noprofile --norc -o errexit -o nounset -o pipefail {0}
 
     env:
       REACT_APP_BNB_MAINNET_RPC_URL: "https://example.com"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,7 +28,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.workingDirectory }}
-        shell: bash
+        shell: bash --noprofile --norc -o errexit -o nounset -o pipefail {0}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION


Notion ticket: https://www.notion.so/exsphere/Improve-error-handling-in-Github-workflows-1260239a528f4d26aa3a7d992d6d8c5d

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
