### PR TITLE
chore(ui): add timeouts for CI workflows

### DIFF
--- a/.github/workflows/ui-verify.yaml
+++ b/.github/workflows/ui-verify.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     # Allow only one concurrent deployment
     concurrency:
@@ -59,6 +60,7 @@ jobs:
 
   storybook:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     # Allow only one concurrent deployment
     concurrency:


### PR DESCRIPTION
There are a few occasions where there is something wrong but the build will not error out at all and it will wait for the default timeout (I think it's 360 minutes). By setting a timeout we get a faster loop that something is wrong and we also get a warning if our workflow increases in time for some valid reason.

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
