### PR TITLE
fix: remove file extensions from workflow triggers

### DIFF
--- a/.github/workflows/aptos-verify.yaml
+++ b/.github/workflows/aptos-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify aptos build"
 on:
   pull_request:
     paths:
-      - "packages/aptos/**/*.{ts,json}"
+      - "packages/aptos/**"
       - ".github/workflows/aptos-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/core-verify.yaml
+++ b/.github/workflows/core-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify core build"
 on:
   pull_request:
     paths:
-      - "packages/core/**/*.{ts,json}"
+      - "packages/core/**"
       - ".github/workflows/core-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/eslint-config-verify.yaml
+++ b/.github/workflows/eslint-config-verify.yaml
@@ -2,8 +2,9 @@ name: "Verify eslint-config build"
 on:
   pull_request:
     paths:
-      - "packages/eslint-config/**.cjs"
-      - "packages/eslint-config/**.json"
+      - "packages/eslint-config/**"
+      - ".github/workflows/verify.yaml"
+      - ".github/workflows/eslint-config-verify.yaml"
   push:
     branches:
       - master

--- a/.github/workflows/evm-contracts-verify.yaml
+++ b/.github/workflows/evm-contracts-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify evm-contracts build"
 on:
   pull_request:
     paths:
-      - "packages/evm-contracts/**/*.{ts,json}"
+      - "packages/evm-contracts/**"
       - ".github/workflows/evm-contracts-verify.yaml"
       - "yarn.lock"
   push:

--- a/.github/workflows/evm-verify.yaml
+++ b/.github/workflows/evm-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify evm build"
 on:
   pull_request:
     paths:
-      - "packages/evm/**/*.{ts,json}"
+      - "packages/evm/**"
       - ".github/workflows/evm-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/pool-math-verify.yaml
+++ b/.github/workflows/pool-math-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify pool-math build"
 on:
   pull_request:
     paths:
-      - "packages/pool-math/**/*.{ts,json}"
+      - "packages/pool-math/**"
       - ".github/workflows/pool-math-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/solana-contracts-verify.yaml
+++ b/.github/workflows/solana-contracts-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify solana-contracts build"
 on:
   pull_request:
     paths:
-      - "packages/solana-contracts/**/*.{ts,json,rs}"
+      - "packages/solana-contracts/**"
       - ".github/workflows/solana-contracts-verify.yaml"
       - "yarn.lock"
   push:

--- a/.github/workflows/solana-verify.yaml
+++ b/.github/workflows/solana-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify solana build"
 on:
   pull_request:
     paths:
-      - "packages/solana/**/*.{ts,json}"
+      - "packages/solana/**"
       - ".github/workflows/solana-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/swim-verify.yaml
+++ b/.github/workflows/swim-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify swim build"
 on:
   pull_request:
     paths:
-      - "packages/swim/**/*.{ts,json}"
+      - "packages/swim/**"
       - ".github/workflows/swim-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/token-projects-verify.yaml
+++ b/.github/workflows/token-projects-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify token-projects build"
 on:
   pull_request:
     paths:
-      - "packages/token-projects/**/*.{ts,json}"
+      - "packages/token-projects/**"
       - ".github/workflows/token-projects-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/tsconfig-verify.yaml
+++ b/.github/workflows/tsconfig-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify tsconfig build"
 on:
   pull_request:
     paths:
-      - "packages/tsconfig/**/*.json"
+      - "packages/tsconfig/**"
       - ".github/workflows/tsconfig-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/ui-verify.yaml
+++ b/.github/workflows/ui-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify UI build"
 on:
   pull_request:
     paths:
-      - "apps/ui/**/*.{js,cjs,mts,ts,tsx,json,scss}"
+      - "apps/ui/**"
       - "yarn.lock"
       - ".github/workflows/ui-verify.yaml"
   push:

--- a/.github/workflows/utils-verify.yaml
+++ b/.github/workflows/utils-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify utils build"
 on:
   pull_request:
     paths:
-      - "packages/utils/**/*.{ts,json}"
+      - "packages/utils/**"
       - ".github/workflows/utils-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"

--- a/.github/workflows/wormhole-verify.yaml
+++ b/.github/workflows/wormhole-verify.yaml
@@ -2,7 +2,7 @@ name: "Verify wormhole build"
 on:
   pull_request:
     paths:
-      - "packages/wormhole/**/*.{ts,json}'"
+      - "packages/wormhole/**"
       - ".github/workflows/wormhole-verify.yaml"
       - ".github/workflows/verify.yaml"
       - "yarn.lock"


### PR DESCRIPTION
It looks like https://github.com/swim-io/swim/pull/443 didn't fix the issue and from [Github docs ](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) I think the `{js,ts,tsx}` syntax is not supported so we either use a new line for each file extension or we just include all files like I did in this PR.

I tested this by rebasing my other PR https://github.com/swim-io/swim/pull/442

Thoughts? 

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
