### PR TITLE
build(ui): update deprecated Github workflow call

### DIFF
--- a/.github/workflows/ui-verify.yaml
+++ b/.github/workflows/ui-verify.yaml
@@ -117,7 +117,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
           npx --yes wrangler@2 pages publish storybook-static --project-name=ui-storybook --branch=${{ github.head_ref || github.ref_name }} | tee wrangler-output.txt
-          echo "::set-output name=storybook-deployment::$(grep Deployment wrangler-output.txt)"
+          echo "storybook-deployment=$(grep Deployment wrangler-output.txt)" >> $GITHUB_OUTPUT
       - name: Find storybook comment
         uses: peter-evans/find-comment@v2
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

Notion ticket: https://www.notion.so/exsphere/Fix-Github-workflows-deprecations-c339ffa32492496f9d3e69d11fdbf79c

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
