### PR TITLE
fix(ui): show what lp token is removed in v1 pool page

### DIFF
--- a/apps/ui/src/components/molecules/InteractionTitle/InteractionTitle.tsx
+++ b/apps/ui/src/components/molecules/InteractionTitle/InteractionTitle.tsx
@@ -64,7 +64,7 @@ export const InteractionTitle: React.FC<Props> = ({ interaction }) => {
       );
     }
     case InteractionType.RemoveUniform: {
-      const { minimumOutputAmounts } = interaction.params;
+      const { minimumOutputAmounts, exactBurnAmount } = interaction.params;
       const nonZeroOutputAmounts = [...minimumOutputAmounts.values()].filter(
         (amount) => !amount.isZero(),
       );
@@ -73,6 +73,7 @@ export const InteractionTitle: React.FC<Props> = ({ interaction }) => {
           <Trans
             i18nKey="recent_interactions.remove_tokens"
             components={{
+              lpToken: <TokenConfigIcon token={exactBurnAmount.tokenConfig} />,
               tokenAmounts: (
                 <AmountsWithTokenIcons amounts={nonZeroOutputAmounts} />
               ),
@@ -82,12 +83,13 @@ export const InteractionTitle: React.FC<Props> = ({ interaction }) => {
       );
     }
     case InteractionType.RemoveExactBurn: {
-      const { minimumOutputAmount } = interaction.params;
+      const { minimumOutputAmount, exactBurnAmount } = interaction.params;
       return (
         <div title={interaction.id}>
           <Trans
             i18nKey="recent_interactions.remove_tokens"
             components={{
+              lpToken: <TokenConfigIcon token={exactBurnAmount.tokenConfig} />,
               tokenAmounts: (
                 <AmountWithTokenIcon
                   amount={minimumOutputAmount}
@@ -100,7 +102,7 @@ export const InteractionTitle: React.FC<Props> = ({ interaction }) => {
       );
     }
     case InteractionType.RemoveExactOutput: {
-      const { exactOutputAmounts } = interaction.params;
+      const { exactOutputAmounts, maximumBurnAmount } = interaction.params;
       const nonZeroOutputAmounts = [...exactOutputAmounts.values()].filter(
         (amount) => !amount.isZero(),
       );
@@ -109,6 +111,9 @@ export const InteractionTitle: React.FC<Props> = ({ interaction }) => {
           <Trans
             i18nKey="recent_interactions.remove_tokens"
             components={{
+              lpToken: (
+                <TokenConfigIcon token={maximumBurnAmount.tokenConfig} />
+              ),
               tokenAmounts: (
                 <AmountsWithTokenIcons amounts={nonZeroOutputAmounts} />
               ),


### PR DESCRIPTION
<!-- Add a short description of your changes unless they are obvious or trivial  -->

Notion ticket: https://www.notion.so/exsphere/Fix-untranslated-placeholder-when-remove-token-925ab449903d46a593357b9f479f0e94

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
