### PR TITLE
docs(ui): Remove mention of deprecated env variables

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -14,8 +14,6 @@ Set required environmental variables:
 
 ```sh
 SKIP_PREFLIGHT_CHECK=true
-REACT_APP_AVALANCHE_DEVNET_RPC_URL=<ask for latest value>
-REACT_APP_POLYGON_DEVNET_RPC_URL=<ask for latest value>
 ```
 
 Run `yarn start` to run the app in development mode.


### PR DESCRIPTION
Note, variables still exist in prod, but Polygon and Avalanche are working correctly in preview. I'll remove prod env variables after :ack:.

[Notion ticket:](https://www.notion.so/exsphere/Update-DEVNET-env-variables-to-TESTNET-3cabe14e4ad5446e86a8e00800e18b11?d=c90eccb4b5734f8385b7c4c0156eb948)

### Checklist

- [x] Github project and label have been assigned
- [x] Tests have been added or are unnecessary
- [x] Docs have been updated or are unnecessary
- [x] Preview deployment works (visit the Cloudflare preview URL)
- [x] Manual testing in #product-testing completed or unnecessary
- [x] New i18n strings do not contain any security vulnerabilities (e.g. should not allow translator to update email/url)
- [x] When fetching new translations from external sources, do a sanity check (e.g. get people who speak the language to check, shove all new translations into Google translate)
